### PR TITLE
Biologic: use less instrument-specific technique names.

### DIFF
--- a/src/tomato/drivers/biologic/kbio_wrapper.py
+++ b/src/tomato/drivers/biologic/kbio_wrapper.py
@@ -85,7 +85,7 @@ def current(val: Union[list,str,float], capacity: float) -> float:
 
 
 def translate(technique: dict, capacity: float) -> dict:
-    if technique["name"] in {"CPLIMIT", "CALIMIT"}:
+    if technique["name"].startswith("constant_"):
         ns = get_num_steps(technique)
         tech = {
             "name": technique["name"],
@@ -113,20 +113,20 @@ def translate(technique: dict, capacity: float) -> dict:
                     tech[f"Test{ci}_Config"] = pad_steps(conf, ns)
                     tech[f"Test{ci}_Value"] = pad_steps(val, ns)
                     ci += 1
-        if technique["name"] == "CPLIMIT":
+        if technique["name"].endswith("current"):
             I = current(technique["current"], capacity)
             tech["Current_step"] = pad_steps(I, ns)
             tech["Record_every_dE"] = technique.get("record_every_dE", 0.005)
-        elif technique["name"] == "CALIMIT":
+        elif technique["name"].endswith("voltage"):
             tech["Voltage_step"] = pad_steps(technique["voltage"], ns)
             tech["Record_every_dI"] = technique.get("record_every_dI", 0.001)
-    elif technique["name"] == "LOOP":
+    elif technique["name"] == "loop":
         tech = {
             "name": "LOOP",
             "loop_N_times": technique.get("n_gotos", -1),
             "protocol_number": technique.get("goto", 0)
         }
-    elif technique["name"] in {"VSCANLIMIT", "ISCANLIMIT"}:
+    elif technique["name"].startswith("sweep_"):
         ns = get_num_steps(technique)
         tech = {
             "name": technique["name"],
@@ -153,22 +153,22 @@ def translate(technique: dict, capacity: float) -> dict:
                     tech[f"Test{ci}_Config"] = pad_steps(conf, ns)
                     tech[f"Test{ci}_Value"] = pad_steps(val, ns)
                     ci += 1
-        if technique["name"] == "ISCANLIMIT":
+        if technique["name"].endswith("current"):
             I = current(technique["current"], capacity)
             tech["Current_step"] = pad_steps(I, ns)
             tech["Begin_measuring_E"] = technique.get("scan_start", 0.0)
             tech["End_measuring_E"] = technique.get("scan_end", 1.0)
             tech["Record_every_dI"] = technique.get("record_every_dI", 0.001)
-        elif technique["name"] == "VSCANLIMIT":
+        elif technique["name"].endswith("voltage"):
             tech["Voltage_step"] = pad_steps(technique["voltage"], ns)
             tech["Begin_measuring_I"] = technique.get("scan_start", 0.0)
             tech["End_measuring_I"] = technique.get("scan_end", 1.0)
             tech["Record_every_dE"] = technique.get("record_every_dE", 0.005)
     else:
-        if technique["name"] != "OCV":
+        if technique["name"] != "open_circuit_voltage":
             log.error(f"technique name '{technique['name']}' not understood.")
         tech = {
-            "name": "OCV",
+            "name": "open_circuit_voltage",
             "Rest_time_T": technique.get("time", 0.0),
             "Record_every_dT": technique.get("record_every_dt", 30.0),
             "Record_every_dE": technique.get("record_every_dE", 0.005),

--- a/src/tomato/drivers/biologic/kbio_wrapper.py
+++ b/src/tomato/drivers/biologic/kbio_wrapper.py
@@ -122,7 +122,7 @@ def translate(technique: dict, capacity: float) -> dict:
             tech["Record_every_dI"] = technique.get("record_every_dI", 0.001)
     elif technique["name"] == "loop":
         tech = {
-            "name": "LOOP",
+            "name": "loop",
             "loop_N_times": technique.get("n_gotos", -1),
             "protocol_number": technique.get("goto", 0)
         }

--- a/src/tomato/drivers/biologic/tech_params.py
+++ b/src/tomato/drivers/biologic/tech_params.py
@@ -48,9 +48,9 @@ I_ranges = {
 
 
 E_ranges = {
-    "±2.5 V": 0,
-    "±5 V": 1,
-    "±10 V": 2,
+    "2.5 V": 0,
+    "5 V": 1,
+    "10 V": 2,
     "auto": 3,
 }
 
@@ -73,19 +73,19 @@ datatypes = {
 
 techfiles = {
     "VMP3": {
-        "OCV": "ocv.ecc",
-        "CPLIMIT": "cplimit.ecc",
-        "CALIMIT": "calimit.ecc",
-        "VSCANLIMIT": "vscanlimit.ecc",
-        "ISCANLIMIT": "iscanlimit.ecc",
-        "LOOP": "loop.ecc"
+        "open_circuit_voltage": "ocv.ecc",
+        "constant_current": "cplimit.ecc",
+        "constant_voltage": "calimit.ecc",
+        "sweep_voltage": "vscanlimit.ecc",
+        "sweep_current": "iscanlimit.ecc",
+        "loop": "loop.ecc"
     },
     "SP-300": {
-        "OCV": "ocv4.ecc",
-        "CPLIMIT": "cplimit4.ecc",
-        "CALIMIT": "calimit4.ecc",
-        "VSCANLIMIT": "vscanlimit4.ecc",
-        "ISCANLIMIT": "iscanlimit4.ecc",
-        "LOOP": "loop4.ecc"
+        "open_circuit_voltage": "ocv4.ecc",
+        "constant_current": "cplimit4.ecc",
+        "constant_voltage": "calimit4.ecc",
+        "sweep_voltage": "vscanlimit4.ecc",
+        "sweep_current": "iscanlimit4.ecc",
+        "loop": "loop4.ecc"
     }
 }

--- a/tests/test.py
+++ b/tests/test.py
@@ -4,57 +4,57 @@ import time
 
 pl = [
     {
-        "name": "OCV", 
+        "name": "open_circuit_voltage", 
         "time": 5, 
         "I_range": "1 mA",
-        "E_range": "±5 V",
+        "E_range": "5 V",
         "record_every_dt": 1
     },
     {
-        "name": "CPLIMIT", 
+        "name": "constant_current", 
         "current": ["C/10", "D/5"],
         "time": 11, 
         "is_delta": False,
         "record_every_dt": 1,
         "record_every_dE": 0.01,
         "I_range": "100 mA",
-        "E_range": "±10 V",
+        "E_range": "10 V",
         "limit_voltage_max": 4.1,
         "limit_voltage_min": 3.0,
         "n_cycles": 2
     },
     {
-        "name": "CPLIMIT",
+        "name": "constant_current",
         "current": "C/8",
         "time": 100,
         "is_delta": False,
         "record_every_dt": 2,
         "I_range": "10 mA",
-        "E_range": "±5 V",
+        "E_range": "5 V",
         "limit_voltage_max": 4.1
     },
     {
-        "name": "CALIMIT",
+        "name": "constant_voltage",
         "voltage": 4.1,
         "time": 180,
         "is_delta": False,
         "record_every_dt": 2,
         "I_range": "10 mA",
-        "E_range": "±5 V",
+        "E_range": "5 V",
         "limit_current_min": "C/10"
     },
     {
-        "name": "CPLIMIT",
+        "name": "constant_current",
         "current": "D/2",
         "time": 100,
         "is_delta": False,
         "record_every_dt": 2,
         "I_range": "100 mA",
-        "E_range": "±10 V",
+        "E_range": "10 V",
         "limit_voltage_min": 3.9
     },
     {
-        "name": "LOOP",
+        "name": "loop",
         "n_gotos": 5,
         "goto": 2
     }

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -4,38 +4,38 @@ import time
 
 pl = [
     {
-        "name": "OCV", 
+        "name": "open_circuit_voltage", 
         "time": 5, 
         "I_range": "1 mA",
-        "E_range": "±5 V",
+        "E_range": "5 V",
         "record_every_dt": 1,
     },
     {
-        "name": "CPLIMIT",
+        "name": "constant_current",
         "time": 20,
         "record_every_dt": 1,
         "current": "C/5",
         "I_range": "10 mA",
-        "E_range": "±5 V",
+        "E_range": "5 V",
         "limit_voltage_max": 4.1,
     },
     {
-        "name": "VSCANLIMIT", 
+        "name": "sweep_voltage", 
         "voltage": [4.1, 3.9, 4.1, 3.8, 4.1],
         "scan_rate": 2.5e-3,
         "record_every_dE": 0.005,
         "n_cycles": 1,
         "I_range": "100 mA",
-        "E_range": "±5 V",
+        "E_range": "5 V",
     },
     {
-        "name": "ISCANLIMIT", 
+        "name": "sweep_current", 
         "current": ["C/10", "D/10", "C/5", "D/5"],
         "scan_rate": 2.5e-3,
         "record_every_dI": 0.005,
         "n_cycles": 2,
         "I_range": "10 mA",
-        "E_range": "±5 V",
+        "E_range": "5 V",
     }
 ]
 


### PR DESCRIPTION
Once merged, the electrochemistry API will look like this:

``` yaml
- name: "open_circuit_voltage"
  time: !!float                  # OCV step length in [s]
  record_every_dt: !!float       # record interval in [s]
  record_every_dE: !!float       # record interval in [V]
  I_range: !!str                 # specified current range
  E_range: !!str                 # specified voltage range
- name: "constant_current"
  time: [!!float,]               # step length in [s]
  current: [!!float,]            # controlled current in [A]
  is_delta: [!!bool,]            # is the current a delta or absolute?
  limit_voltage_max: [!!float,]  # upper bound of voltage in [V]
  limit_voltage_min: [!!float,]  # lower bound of voltage in [V]
  limit_current_max: [!!float,]  # upper bound of current in [A]
  limit_current_min: [!!float,]  # lower bound of current in [A]
  record_every_dt: !!float       # record interval in [s]
  record_every_dE: !!float       # record interval in [V]
  n_cycles: !!int                # repeat whole sequence
  I_range: !!str                 # specified current range
  E_range: !!str                 # specified voltage range
- name: "constant_voltage"
  time: [!!float,]               # step length in [s]
  voltage: [!!float,]            # controlled voltage in [V]
  is_delta: [!!bool,]            # is the voltage a delta or absolute?
  limit_voltage_max: [!!float,]  # upper bound of voltage in [V]
  limit_voltage_min: [!!float,]  # lower bound of voltage in [V]
  limit_current_max: [!!float,]  # upper bound of current in [A]
  limit_current_min: [!!float,]  # lower bound of current in [A]
  record_every_dt: !!float       # record interval in [s]
  record_every_dI: !!float       # record interval in [A]
  n_cycles: !!int                # repeat whole sequence
  I_range: !!str                 # specified current range
  E_range: !!str                 # specified voltage range
- name: "sweep_current"
  current: [!!float,]            # target current in [A]
  is_delta: [!!bool,]            # is the current a delta or absolute?
  scan_rate: [!!float,]          # sweep rate of current in [A/s]
  limit_voltage_max: [!!float,]  # upper bound of voltage in [V]
  limit_voltage_min: [!!float,]  # lower bound of voltage in [V]
  limit_current_max: [!!float,]  # upper bound of current in [A]
  limit_current_min: [!!float,]  # lower bound of current in [A]
  scan_start: !!float            # begin averaging at fraction [0 - 1)
  scan_end: !!float              # end averaging at fraction (0 - 1]
  record_every_dE: !!float       # record interval in [V]
  n_cycles: !!int                # repeat whole sequence
  I_range: !!str                 # specified current range
  E_range: !!str                 # specified voltage range
- name: "sweep_voltage"
  voltage: [!!float,]            # target voltage in [V]
  is_delta: [!!bool,]            # is the voltage a delta or absolute?
  scan_rate: [!!float,]          # sweep rate of current in [V/s]
  limit_voltage_max: [!!float,]  # upper bound of voltage in [V]
  limit_voltage_min: [!!float,]  # lower bound of voltage in [V]
  limit_current_max: [!!float,]  # upper bound of current in [A]
  limit_current_min: [!!float,]  # lower bound of current in [A]
  scan_start: !!float            # begin averaging at fraction [0 - 1)
  scan_end: !!float              # end averaging at fraction (0 - 1]
  record_every_dI: !!float       # record interval in [A]
  n_cycles: !!int                # repeat whole sequence
  I_range: !!str                 # specified current range
  E_range: !!str                 # specified voltage range
- loop:
  n_gotos: !!int                 # number of loops, -1 for infinite
  goto: !!int                    # 0-indexed index of technique to loop from
```

Note: the array quantities determine the number of steps within each technique. If a non-array quantity is supplied, this constant value will be applied for each of the steps.

Note: the maximum number of limits in each technique is 3, despite the 4 keywords available.

Note: all currents can be specified as a `str` instead of `float` by using C or D rate notation.