### PR TITLE
Move to subprocess

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setuptools.setup(
         "console_scripts": [
             "tomato=tomato:run_tomato",
             "ketchup=tomato:run_ketchup",
+            "tomato_worker=tomato.daemon:job_wrapper"
         ]
     },
 )

--- a/src/tomato/daemon/__init__.py
+++ b/src/tomato/daemon/__init__.py
@@ -1,1 +1,1 @@
-from .main import main_loop
+from .main import main_loop, job_wrapper

--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -119,7 +119,8 @@ def main_loop(settings: dict, pipelines: dict) -> None:
                         with open(jpath, "w") as of:
                             json.dump(args, of, indent=1)
                         p = subprocess.Popen(
-                            ["tomato_worker", str(jpath)]
+                            ["tomato_worker", str(jpath)], 
+                            creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NO_WINDOW
                         )
                         break
         time.sleep(settings.get("main loop", 1))

--- a/src/tomato/dbhandler/sqlite.py
+++ b/src/tomato/dbhandler/sqlite.py
@@ -202,7 +202,7 @@ def pipeline_remove(
 ) -> None:
     conn, cur = get_db_conn(dbpath, type)
     log.warning(f"deleting pipeline '{pip}' from 'state'")
-    cur.execute("DELETE FROM state WHERE pipeline='{pip}';")
+    cur.execute(f"DELETE FROM state WHERE pipeline='{pip}';")
     conn.commit()
     conn.close()
 

--- a/src/tomato/drivers/__init__.py
+++ b/src/tomato/drivers/__init__.py
@@ -1,2 +1,2 @@
-from . import biologic
+from . import biologic, dummy
 from .driver_funcs import driver_api, driver_worker

--- a/src/tomato/drivers/dummy/__init__.py
+++ b/src/tomato/drivers/dummy/__init__.py
@@ -1,0 +1,7 @@
+"""
+`dummy`: A dummy driver module
+
+This is a driver for debugging purposes.
+
+"""
+from .main import get_status, get_data, start_job, stop_job

--- a/src/tomato/drivers/dummy/main.py
+++ b/src/tomato/drivers/dummy/main.py
@@ -1,0 +1,138 @@
+import logging
+import random
+
+log = logging.getLogger(__name__)
+from datetime import datetime, timezone
+
+
+def get_status(
+    address: str,
+    channel: int,
+    **kwargs: dict,
+) -> tuple[float, dict]:
+    """
+    Get the current status of the device.
+
+    Parameters
+    ----------
+    address
+        Not used
+
+    channel
+        Numeric, 1-indexed ID of the channel.
+
+    dllpath
+        Path to the BioLogic DLL file.
+
+    Returns
+    -------
+    timestamp, ready, metadata: tuple[float, bool, dict]
+        Returns a tuple containing the timestamp, readiness status, and
+        associated metadata.
+
+    """
+    dt = datetime.now(timezone.utc)
+    return dt.timestamp(), True, {}
+
+
+def get_data(
+    address: str,
+    channel: int,
+    **kwargs: dict,
+) -> tuple[float, dict]:
+    """
+    Get cached data from the device.
+
+    Parameters
+    ----------
+    address
+        IP address of the potentiostat.
+
+    channel
+        Numeric, 1-indexed ID of the channel.
+
+    dllpath
+        Path to the BioLogic DLL file.
+
+    Returns
+    -------
+    timestamp, nrows, data: tuple[float, int, dict]
+        Returns a tuple containing the timestamp and associated metadata.
+
+    """
+    dt = datetime.now(timezone.utc)
+    npoints = random.randint(0, channel) // 2
+    points = []
+    for i in range(npoints):
+        points.append({"value": random.random()*100})
+    data = {"data": points}
+    return dt.timestamp(), npoints, data
+
+
+def start_job(
+    address: str,
+    channel: int,
+    **kwargs: dict,
+) -> float:
+    """
+    Start a job on the device.
+
+    Parameters
+    ----------
+    address
+        IP address of the potentiostat.
+
+    channel
+        Numeric, 1-indexed ID of the channel.
+
+    dllpath
+        Path to the BioLogic DLL file.
+
+    payload
+        A protocol describing the techniques to be executed and their order.
+
+    capacity
+        The capacity information for the studied battery cell. Only required for
+        battery-testing applications or for payloads where currents are specified
+        using C or D rates.
+
+    Returns
+    -------
+    timestamp
+        A timestamp corresponding to the start of the job execution.
+
+    """
+    dt = datetime.now(timezone.utc)
+    return dt.timestamp()
+
+
+def stop_job(
+    address: str,
+    channel: int,
+    **kwargs: dict,
+) -> float:
+    """
+    Stop a job running on the device.
+
+    This function stops any currently running technique on the specified channel
+    of the device. No data is returned.
+
+    Parameters
+    ----------
+    address
+        IP address of the potentiostat.
+
+    channel
+        Numeric, 1-indexed ID of the channel.
+
+    dllpath
+        Path to the BioLogic DLL file.
+
+    Returns
+    -------
+    timestamp
+        A timestamp corresponding to the start of the job execution.
+
+    """
+    dt = datetime.now(timezone.utc)
+    return dt.timestamp()

--- a/tests/test_dummy.yml
+++ b/tests/test_dummy.yml
@@ -1,0 +1,8 @@
+sample:
+    name: sample
+method:
+    worker:
+        - name: "random"
+          payload: bla
+tomato:
+    unlock_when_done: false


### PR DESCRIPTION
Move running worker jobs to `subprocess.Popen` instead of `multiprocess.Process`.

Also an initial implementation of the `dummy` device.