### PR TITLE
Export functionality.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setuptools.setup(
         "Bug Tracker": "https://github.com/dgbowl/tomato/issues",
     },
     classifiers=[
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
     ],
@@ -34,6 +35,7 @@ setuptools.setup(
         "toml",
         "pyyaml",
         "psutil",
+        "yadg @ git+https://github.com/PeterKraus/yadg.git@tomatojson#egg=yadg"
     ],
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setuptools.setup(
         "toml",
         "pyyaml",
         "psutil",
-        "yadg @ git+https://github.com/PeterKraus/yadg.git@tomatojson#egg=yadg"
+        "yadg>=4.1.0rc5"
+        #"yadg @ git+https://github.com/PeterKraus/yadg.git@tomatojson#egg=yadg"
     ],
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setuptools.setup(
         "toml",
         "pyyaml",
         "psutil",
-        "yadg>=4.1.0rc5"
-        #"yadg @ git+https://github.com/PeterKraus/yadg.git@tomatojson#egg=yadg"
+        #"yadg>=4.1.0rc5"
+        "yadg @ git+https://github.com/dgbowl/yadg.git@master#egg=yadg"
     ],
     extras_require={
         "testing": [

--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -9,13 +9,9 @@ from ..drivers import driver_worker, driver_reset, tomato_job
 from .. import dbhandler
 
 
-def _find_matching_pipelines(pipelines: list, method: dict) -> list[str]:
-    req_names = set(method.keys())
-    req_capabs = []
-    for k in req_names:
-        for s in method[k]:
-            req_capabs.append(s["name"])
-    req_capabs = set(req_capabs)
+def _find_matching_pipelines(pipelines: list, method: list[dict]) -> list[str]:
+    req_names = set([item["device"] for item in method])
+    req_capabs = set([item["technique"] for item in method])
 
     candidates = []
     for cd in pipelines:
@@ -94,7 +90,7 @@ def main_loop(settings: dict, pipelines: dict) -> None:
                         with open(jpath, "w") as of:
                             json.dump(args, of, indent=1)
                         cfs = subprocess.CREATE_NO_WINDOW
-                        cfs |= subprocess.CREATE_NEW_PROCESS_GROUP
+                        #cfs |= subprocess.CREATE_NEW_PROCESS_GROUP
                         subprocess.Popen(
                             ["tomato_job", str(jpath)],
                             creationflags=cfs,

--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -90,7 +90,7 @@ def main_loop(settings: dict, pipelines: dict) -> None:
                         with open(jpath, "w") as of:
                             json.dump(args, of, indent=1)
                         cfs = subprocess.CREATE_NO_WINDOW
-                        #cfs |= subprocess.CREATE_NEW_PROCESS_GROUP
+                        # cfs |= subprocess.CREATE_NEW_PROCESS_GROUP
                         subprocess.Popen(
                             ["tomato_job", str(jpath)],
                             creationflags=cfs,

--- a/src/tomato/drivers/driver_funcs.py
+++ b/src/tomato/drivers/driver_funcs.py
@@ -14,6 +14,7 @@ from .logger_funcs import log_listener_config, log_listener, log_worker_config
 from .yadg_funcs import get_yadg_preset
 from .. import dbhandler
 
+
 def tomato_job() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -51,12 +52,12 @@ def tomato_job() -> None:
     tomato = payload.get("tomato", {})
     pipeline = jsdata["pipeline"]
     pip = pipeline["name"]
-    
+
     verbosity = tomato.get("verbosity", "INFO")
     loglevel = logging._checkLevel(verbosity)
     logger.debug("setting logger verbosity to '%s'", verbosity)
     logger.setLevel(loglevel)
-    
+
     pid = os.getpid()
 
     logger.debug(f"assigning job '{jobid}' on pid '{pid}' into pipeline '{pip}'")
@@ -69,14 +70,14 @@ def tomato_job() -> None:
     ret = driver_worker(settings, pipeline, payload, jobid, logfile, loglevel)
 
     logger.info("==============================")
-    
+
     output = tomato.get("output", {"prefix": f"results.{jobid}"})
     dgfile = f"{output['prefix']}.json"
     logging.debug("creating a preset file '%s'", f"preset.{jobid}.json")
     preset = get_yadg_preset(payload["method"], pipeline)
     with open(f"preset.{jobid}.json", "w") as of:
         json.dump(preset, of)
-    
+
     logging.info("running yadg to create a datagram in '%s'", dgfile)
     command = ["yadg", "preset", "-pa", f"preset.{jobid}.json", jobfolder, dgfile]
     logging.debug(" ".join(command))
@@ -100,7 +101,6 @@ def tomato_job() -> None:
     logger.debug(f"setting pipeline '{pip}' as '{'ready' if ready else 'not ready'}'")
     dbhandler.pipeline_reset_job(state["path"], pip, ready, type=state["type"])
     dbhandler.job_set_time(queue["path"], "completed_at", jobid, type=queue["type"])
-
 
 
 def driver_api(
@@ -164,10 +164,10 @@ def data_poller(
 
 
 def driver_worker(
-    settings: dict, 
-    pipeline: dict, 
-    payload: dict, 
-    jobid: int, 
+    settings: dict,
+    pipeline: dict,
+    payload: dict,
+    jobid: int,
     logfile: str,
     loglevel: int,
 ) -> None:

--- a/src/tomato/drivers/driver_funcs.py
+++ b/src/tomato/drivers/driver_funcs.py
@@ -71,8 +71,14 @@ def tomato_job() -> None:
 
     logger.info("==============================")
 
-    output = tomato.get("output", {"prefix": f"results.{jobid}"})
-    dgfile = f"{output['prefix']}.json"
+    output = tomato.get("output", {})
+    prefix = output.get("prefix", f"results.{jobid}")
+    path = output.get("path", ".")
+    if os.path.exists(path):
+        assert os.path.isdir(path)
+    else:
+        os.makedirs(path)
+    dgfile = os.path.join(path, f"{prefix}.json")
     logging.debug("creating a preset file '%s'", f"preset.{jobid}.json")
     preset = get_yadg_preset(payload["method"], pipeline)
     with open(f"preset.{jobid}.json", "w") as of:

--- a/src/tomato/drivers/driver_funcs.py
+++ b/src/tomato/drivers/driver_funcs.py
@@ -206,9 +206,8 @@ def driver_worker(
         )
         metadata["uts"] = start_ts
 
-        log.debug(f"{vi+1}: writing metadata")
-        isots = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace(":", "")
-        fn = os.path.join(root, f"{tag}_{isots}_status.json")
+        log.debug(f"{vi+1}: writing initial status")
+        fn = os.path.join(root, f"{tag}_status.json")
         with open(fn, "w") as of:
             json.dump(metadata, of)
         kwargs = dpar

--- a/src/tomato/drivers/dummy/main.py
+++ b/src/tomato/drivers/dummy/main.py
@@ -155,7 +155,7 @@ def start_job(
         )
         pr.start()
     # Delay before quitting so that processes get a chance to start
-    time.sleep(1) 
+    time.sleep(1)
     return dt.timestamp()
 
 

--- a/src/tomato/drivers/dummy/main.py
+++ b/src/tomato/drivers/dummy/main.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 def _dummy_process(
     queue: multiprocessing.Queue,
-    name: str = "random",
+    tech: str = "random",
     delay: int = 1,
     t: int = 10,
 ) -> None:
@@ -21,7 +21,7 @@ def _dummy_process(
             nd += 1
             data = {
                 "time": te - ts,
-                "value": random.random() if name == "random" else nd,
+                "value": random.random() if tech == "random" else nd,
             }
             queue.put(data)
         time.sleep(1e-3)
@@ -142,15 +142,16 @@ def start_job(
     """
     dt = datetime.now(timezone.utc)
     logger.info("in 'dummy.start_job'")
+    logger.debug(f"{payload=}")
     for ip, p in enumerate(payload):
         delay = p.get("delay", 1)
         t = p.get("time", 10)
-        name = p["name"]
+        tech = p["technique"]
         logger.debug(
-            f"starting 'dummy._dummy_process' {ip} with {name=}, {t=}, {delay=}."
+            f"starting 'dummy._dummy_process' {ip} with {tech=}, {t=}, {delay=}."
         )
         pr = multiprocessing.Process(
-            target=_dummy_process, args=(jobqueue, name, delay, t)
+            target=_dummy_process, args=(jobqueue, tech, delay, t)
         )
         pr.start()
     # Delay before quitting so that processes get a chance to start

--- a/src/tomato/drivers/logger_funcs.py
+++ b/src/tomato/drivers/logger_funcs.py
@@ -20,7 +20,7 @@ def log_listener(queue, configurer, path):
         logger.handle(record)
 
 
-def log_worker_config(queue, loglevel = logging.INFO):
+def log_worker_config(queue, loglevel=logging.INFO):
     h = logging.handlers.QueueHandler(queue)
     root = logging.getLogger()
     root.addHandler(h)

--- a/src/tomato/drivers/yadg_funcs.py
+++ b/src/tomato/drivers/yadg_funcs.py
@@ -21,6 +21,15 @@ def get_yadg_preset(method: list[dict], pipeline: dict) -> dict:
             "parser": _device_to_parser[devices[dev]],
             "input": {"folders": ["."], "prefix": dev, "suffix": "data.json"},
             "parameters": {"filetype": "tomato.json"},
+            "externaldate": {
+                "using": {
+                    "file": {
+                        "type": "json",
+                        "path": f"{dev}_status.json",
+                        "match": "uts"
+                    }
+                },
+            }
         }
         preset["steps"].append(step)
     return preset

--- a/src/tomato/drivers/yadg_funcs.py
+++ b/src/tomato/drivers/yadg_funcs.py
@@ -1,0 +1,35 @@
+
+_device_to_parser = {
+    "dummy": "dummy",
+    "biologic": "electrochem",
+}
+
+def get_yadg_preset(method: list[dict], pipeline: dict) -> dict:
+    preset = {
+        "metadata": {
+            "version": "4.1.1",
+            "provenance": {
+                "type": "tomato"
+            },
+            "timezone": "localtime"
+        },
+        "steps": []
+    }
+
+    devices = {item["tag"]: item["driver"] for item in pipeline["devices"]}
+    for dev in set([item["device"] for item in method]):
+        step = {
+            "tag": dev,
+            "parser": _device_to_parser[devices[dev]],
+            "input": {
+                "folders": ["."],
+                "prefix": dev,
+                "suffix": "data.json"
+            },
+            "parameters": {
+                "filetype": "tomato.json"
+            }
+        }
+        preset["steps"].append(step)
+    return preset
+        

--- a/src/tomato/drivers/yadg_funcs.py
+++ b/src/tomato/drivers/yadg_funcs.py
@@ -1,19 +1,17 @@
-
 _device_to_parser = {
     "dummy": "dummy",
     "biologic": "electrochem",
 }
 
+
 def get_yadg_preset(method: list[dict], pipeline: dict) -> dict:
     preset = {
         "metadata": {
             "version": "4.1.1",
-            "provenance": {
-                "type": "tomato"
-            },
-            "timezone": "localtime"
+            "provenance": {"type": "tomato"},
+            "timezone": "localtime",
         },
-        "steps": []
+        "steps": [],
     }
 
     devices = {item["tag"]: item["driver"] for item in pipeline["devices"]}
@@ -21,15 +19,8 @@ def get_yadg_preset(method: list[dict], pipeline: dict) -> dict:
         step = {
             "tag": dev,
             "parser": _device_to_parser[devices[dev]],
-            "input": {
-                "folders": ["."],
-                "prefix": dev,
-                "suffix": "data.json"
-            },
-            "parameters": {
-                "filetype": "tomato.json"
-            }
+            "input": {"folders": ["."], "prefix": dev, "suffix": "data.json"},
+            "parameters": {"filetype": "tomato.json"},
         }
         preset["steps"].append(step)
     return preset
-        

--- a/src/tomato/setlib/functions.py
+++ b/src/tomato/setlib/functions.py
@@ -83,7 +83,7 @@ def _default_pipelines() -> dict[str, dict]:
                 "address": None,
                 "channels": [5, 10],
                 "driver": "dummy",
-                "capabilities": ["random"],
+                "capabilities": ["random", "sequential"],
                 "pollrate": 1,
             }
         ],

--- a/tests/common/dummy_random_1_0.1.yml
+++ b/tests/common/dummy_random_1_0.1.yml
@@ -1,0 +1,10 @@
+sample:
+    name: dummy_random_1_0.1
+method:
+  - device: "worker"
+    technique: "random"
+    time: 1
+    delay: 0.1
+tomato:
+    output:
+        path: newfolder

--- a/tests/common/dummy_random_2_0.1.yml
+++ b/tests/common/dummy_random_2_0.1.yml
@@ -1,9 +1,9 @@
 sample:
     name: dummy_random_2_0.1
 method:
-    worker:
-        - name: "random"
-          time: 2
-          delay: 0.1
+  - device: "worker"
+    technique: "random"
+    time: 2
+    delay: 0.1
 tomato:
     verbosity: "DEBUG"

--- a/tests/common/dummy_random_5_2.yml
+++ b/tests/common/dummy_random_5_2.yml
@@ -1,7 +1,7 @@
 sample:
     name: dummy_random_5_2
 method:
-    worker:
-        - name: "random"
-          time: 5
-          delay: 2
+  - device: "worker"
+    technique: "random"
+    time: 5
+    delay: 2

--- a/tests/common/dummy_sequential_1_0.05.yml
+++ b/tests/common/dummy_sequential_1_0.05.yml
@@ -1,0 +1,11 @@
+sample:
+    name: dummy_sequential_1_0.05
+method:
+  - device: "worker"
+    technique: "sequential"
+    time: 1
+    delay: 0.05
+tomato:
+    verbosity: "DEBUG"
+    output:
+        prefix: data

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -9,19 +9,26 @@ from . import utils
 
 
 @pytest.mark.parametrize(
-    "casename, npoints",
+    "casename, npoints, prefix",
     [
         (
             "dummy_random_2_0.1",
             20,
+            "results.1",
         ),
         (
             "dummy_random_5_2",
             3,
+            "results.1",
+        ),
+        (
+            "dummy_sequential_1_0.05",
+            20,
+            "data",
         ),
     ],
 )
-def test_run_dummy_random(casename, npoints, datadir):
+def test_run_dummy_random(casename, npoints, prefix, datadir):
     os.chdir(datadir)
     status = utils.run_casename(casename)
     assert status == "c"
@@ -36,3 +43,10 @@ def test_run_dummy_random(casename, npoints, datadir):
                 for point in jsdata["data"]:
                     data.append(point)
     assert len(data) == npoints
+    if prefix is not None:
+        print(os.listdir())
+        assert os.path.exists(f"{prefix}.json")
+        assert os.path.exists(f"{prefix}.zip")
+        with open(f"{prefix}.json", "r") as of:
+            dg = json.load(of)
+        assert len(dg["steps"][0]["data"]) == npoints

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -26,6 +26,11 @@ from . import utils
             20,
             "data",
         ),
+        (
+            "dummy_random_1_0.1",
+            10,
+            os.path.join("newfolder", "results.1"),
+        ),
     ],
 )
 def test_run_dummy_random(casename, npoints, prefix, datadir):

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -44,7 +44,6 @@ def test_run_dummy_random(casename, npoints, prefix, datadir):
                     data.append(point)
     assert len(data) == npoints
     if prefix is not None:
-        print(os.listdir())
         assert os.path.exists(f"{prefix}.json")
         assert os.path.exists(f"{prefix}.zip")
         with open(f"{prefix}.json", "r") as of:


### PR DESCRIPTION
Adds export functionality to `tomato`, leveraging `yadg preset -pa` and closing #19:

- [x] by default, completed jobs are exported into a datagram and zip archive as `results.{jobid}.[json/zip]`
- [x] the file prefix can be modified using `tomato: output: prefix: str`
- [x] the timestamp can be completed using the `status.json` file
- [x] the archive and datagram can be exported in a different folder than the `cwd` by using `tomato: output: path: str`

Note, this PR requires the https://github.com/dgbowl/yadg/pull/57 PR to be merged, after which the `setup.py` needs to be modified to refer to a packaged version of `yadg`.