### PR TITLE
Specify target folder using `output: path`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setuptools.setup(
         "toml",
         "pyyaml",
         "psutil",
-        #"yadg>=4.1.0rc5"
-        "yadg @ git+https://github.com/dgbowl/yadg.git@master#egg=yadg"
+        "yadg>=4.1",
     ],
     extras_require={
         "testing": [

--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -4,8 +4,6 @@ import subprocess
 import time
 import json
 import logging
-
-from ..drivers import driver_worker, driver_reset, tomato_job
 from .. import dbhandler
 
 

--- a/src/tomato/drivers/driver_funcs.py
+++ b/src/tomato/drivers/driver_funcs.py
@@ -74,9 +74,12 @@ def tomato_job() -> None:
     output = tomato.get("output", {})
     prefix = output.get("prefix", f"results.{jobid}")
     path = output.get("path", ".")
+    logger.debug("output path is '%s'", path)
     if os.path.exists(path):
+        logger.debug("path exists, making sure it's a folder")
         assert os.path.isdir(path)
     else:
+        logger.debug("path does not exist, creating")
         os.makedirs(path)
     dgfile = os.path.join(path, f"{prefix}.json")
     logging.debug("creating a preset file '%s'", f"preset.{jobid}.json")

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -24,6 +24,12 @@ def submit(args):
             payload = json.load(infile)
         elif args.payload.endswith("yml") or args.payload.endswith("yaml"):
             payload = yaml.full_load(infile)
+    if "tomato" not in payload:
+        payload["tomato"] = {}
+    if "output" not in payload["tomato"]:
+        payload["tomato"]["output"] = {}
+    if "path" not in payload["tomato"]["output"]:
+        payload["tomato"]["output"]["path"] = os.getcwd()
     pstr = json.dumps(payload)
     log.info("queueing 'payload' into 'queue'")
     dbhandler.queue_payload(queue["path"], pstr, type=queue["type"])

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -29,7 +29,9 @@ def submit(args):
     if "output" not in payload["tomato"]:
         payload["tomato"]["output"] = {}
     if "path" not in payload["tomato"]["output"]:
-        payload["tomato"]["output"]["path"] = os.getcwd()
+        cwd = os.getcwd()
+        log.info("Output path not set. Setting output path to '%s'", cwd)
+        payload["tomato"]["output"]["path"] = cwd
     pstr = json.dumps(payload)
     log.info("queueing 'payload' into 'queue'")
     dbhandler.queue_payload(queue["path"], pstr, type=queue["type"])

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -4,6 +4,7 @@ import yaml
 import logging
 import signal
 import psutil
+from pathlib import Path
 from .. import setlib
 from .. import dbhandler
 
@@ -29,7 +30,7 @@ def submit(args):
     if "output" not in payload["tomato"]:
         payload["tomato"]["output"] = {}
     if "path" not in payload["tomato"]["output"]:
-        cwd = os.getcwd()
+        cwd = str(Path().resolve())
         log.info("Output path not set. Setting output path to '%s'", cwd)
         payload["tomato"]["output"]["path"] = cwd
     pstr = json.dumps(payload)


### PR DESCRIPTION
This PR explicitly fills in `tomato: output: path` with the current working directory when a job is submitted with `ketchup submit`. It also handles submitting from network drives on windows, by resolving them using `pathlib`.