### PR TITLE
Stop crashes on `ketchup cancel`.

### DIFF
--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -50,7 +50,7 @@ def main_loop(settings: dict, pipelines: dict, test: bool = False) -> None:
         ret = dbhandler.pipeline_get_running(stp, type=stt)
         for pip, jobid, pid in ret:
             log.debug(f"checking PID of running job '{jobid}'")
-            if psutil.pid_exists(pid) and "python" in psutil.Process(pid).name():
+            if psutil.pid_exists(pid) and "tomato_job" in psutil.Process(pid).name():
                 log.debug(f"PID of running job '{jobid}' found")
                 # dbhandler.job_set_status(queue, "r", jobid)
             else:

--- a/src/tomato/drivers/driver_funcs.py
+++ b/src/tomato/drivers/driver_funcs.py
@@ -263,8 +263,10 @@ def driver_reset(
         dpar = settings["drivers"].get(drv, {})
 
         log.debug(f"{vi+1}: resetting device")
-        driver_api(drv, "stop_job", addr, ch, **dpar)
+        driver_api(drv, "stop_job", None, log, addr, ch, **dpar)
 
         log.debug(f"{vi+1}: getting status")
-        ts, ready, metadata = driver_api(drv, "get_status", addr, ch, **dpar)
+        ts, ready, metadata = driver_api(
+            drv, "get_status", None, log, addr, ch, **dpar
+        )
         assert ready, f"Failed: device '{tag}' is not ready."

--- a/src/tomato/drivers/driver_funcs.py
+++ b/src/tomato/drivers/driver_funcs.py
@@ -58,7 +58,8 @@ def tomato_job() -> None:
     logger.debug("setting logger verbosity to '%s'", verbosity)
     logger.setLevel(loglevel)
 
-    pid = os.getpid()
+    #pid = os.getpid()
+    pid = os.getppid() # On Windows, the parent is the tomato_job.exe
 
     logger.debug(f"assigning job '{jobid}' on pid '{pid}' into pipeline '{pip}'")
     dbhandler.pipeline_assign_job(state["path"], pip, jobid, pid, type=state["type"])

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -107,10 +107,17 @@ def cancel(args):
             if pjobid == jobid:
                 log.warning(f"cancelling a running job {jobid} with pid {pid}")
                 proc = psutil.Process(pid=pid)
-                cproc = proc.children()
-                for p in cproc:
-                    p.send_signal(signal.SIGTERM)
-                    log.debug(f"SIGTERM sent to pid {p.pid}")
+                for cp in proc.children():
+                    if cp.name() in {"python", "python.exe"}:
+                        for ccp in cp.children():
+                            log.debug(
+                                "sending SIGTERM to pid %d with name '%s'",
+                                ccp.pid,
+                                ccp.name()
+                            )
+                            ccp.send_signal(signal.SIGTERM)
+                        
+                    
 
 
 def load(args):

--- a/src/tomato/main.py
+++ b/src/tomato/main.py
@@ -78,7 +78,7 @@ def run_tomato():
     args = parser.parse_args()
     _logging_setup(args)
 
-    ppid = os.getppid()
+    ppid = os.getppid() # On Windows, tomato.exe is the parent of os.getpid()
     toms = [
         p.pid for p in psutil.process_iter() if p.name() in {"tomato", "tomato.exe"}
     ]


### PR DESCRIPTION
The job process ID's and the `ketchup cancel` command were not implemented properly. This PR makes sure that `tomato.exe` and `tomato_job.exe` are the processes of which `pid` is stored (on Windows), that the correct job processes are sent `SIGTERM`, and that the `driver_reset` command does not crash due to wrong function signature.