### PR TITLE
Swap portalocker for filelock

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,19 +20,14 @@ and can be installed using:
 
 .. code::
 
-    pip install tomato
+    pip install tomato[docs,testing]
+
+The optional targets ``[docs]`` and ``[testing]`` will install packages required for
+building the documentation and running the test-suite, respectively.
 
 .. note::
 
-    We strongly recommend installing **tomato** into a separate conda environment. 
-    Additionally, **tomato** depends on ``portalocker``, which can be installed from
-    conda's defaults channel. You can easily create a new conda environment and install
-    the required packages using:
-
-    .. code::
-
-        conda create -n tomato python=3.9 portalocker git pip
-        pip install tomato
+    We strongly recommend installing **tomato** into a separate conda environment.
 
 
 Usage

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "psutil",
         "yadg>=4.1",
         "dgbowl_schemas>=105",
-        "portalocker",
+        "filelock",
     ],
     extras_require={
         "testing": [

--- a/src/tomato/drivers/biologic/main.py
+++ b/src/tomato/drivers/biologic/main.py
@@ -1,7 +1,7 @@
 import logging
 import multiprocessing
 import time
-import portalocker
+from filelock import FileLock
 
 from datetime import datetime, timezone
 
@@ -46,7 +46,7 @@ def get_status(
     api = get_kbio_api(dllpath)
     metadata = {}
     metadata["dll_version"] = api.GetLibVersion()
-    with portalocker.Lock(lockpath, timeout=60) as fh:
+    with FileLock(lockpath, timeout=60) as fh:
         try:
             logger.info(f"connecting to '{address}:{channel}'")
             id_, device_info = api.Connect(address)
@@ -103,7 +103,7 @@ def get_data(
 
     """
     api = get_kbio_api(dllpath)
-    with portalocker.Lock(lockpath, timeout=60) as fh:
+    with FileLock(lockpath, timeout=60) as fh:
         try:
             logger.info(f"connecting to '{address}:{channel}'")
             id_, device_info = api.Connect(address)
@@ -166,7 +166,7 @@ def start_job(
     logger.debug("translating payload to ECC")
     eccpars = payload_to_ecc(api, payload, capacity)
     ntechs = len(eccpars)
-    with portalocker.Lock(lockpath, timeout=60) as fh:
+    with FileLock(lockpath, timeout=60) as fh:
         try:
             first = True
             last = False
@@ -227,7 +227,7 @@ def stop_job(
 
     """
     api = get_kbio_api(dllpath)
-    with portalocker.Lock(lockpath, timeout=60) as fh:
+    with FileLock(lockpath, timeout=60) as fh:
         try:
             logger.info(f"connecting to '{address}:{channel}'")
             id_, device_info = api.Connect(address)


### PR DESCRIPTION
This swaps the dependency on the `portalocker` package (which depends on `pywin32`) for `filelock`, which is much lighter. Should make the installation a lot easier, as `pywin32` from pypi doesn't work. Needs to be tested on hardware before merging.