### PR TITLE
Implement `ketchup search`

### DIFF
--- a/src/tomato/ketchup/__init__.py
+++ b/src/tomato/ketchup/__init__.py
@@ -18,4 +18,4 @@ Also includes *sample*/*pipeline* management functions:
 
 
 """
-from .functions import submit, status, cancel, load, eject, ready, snapshot
+from .functions import submit, status, cancel, load, eject, ready, snapshot, search

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -428,3 +428,43 @@ def snapshot(args: Namespace) -> None:
     yadg_funcs.process_yadg_preset(
         preset=preset, path=".", prefix=f"snapshot.{jobid}", jobdir=jobdir
     )
+
+
+def search(args: Namespace) -> None:
+    """
+    Search the queue for a job that matches a given jobname. Usage:
+
+    .. code:: bash
+
+        ketchup [-t] [-v] [-q] [-c] search <jobname>
+
+    Searches the ``queue`` for a job that matches the ``jobname``, returns the
+    job status and ``jobid``. If the option ``-c/--complete`` is specified,
+    the completed jobs will also be searched.
+    
+    .. note:: 
+
+        Output of ``ketchup search`` is a valid ``yaml``.
+
+    Examples
+    --------
+
+    >>> # Create a snapshot in current working directory:
+    >>> ketchup submit .\dummy_random_2_0.1.yml -j dummy_random_2_0.1
+    >>> ketchup search dummy_random_2
+    - jobname: dummy_random_2_0.1
+      jobid: 1
+      status: r
+
+    """
+    dirs = setlib.get_dirs(args.test)
+    settings = setlib.get_settings(dirs.user_config_dir, dirs.user_data_dir)
+    queue = settings["queue"]
+    
+    alljobs = dbhandler.job_get_all(queue["path"], type=queue["type"])
+    for jobid, jobname, payload, status in alljobs:
+        if jobname is not None and args.jobname in jobname:
+            if args.complete or not status.startswith("c"):
+                print(f"- jobname: {jobname}")
+                print(f"  jobid: {jobid}")
+                print(f"  status: {status}")

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -239,7 +239,12 @@ def cancel(args: Namespace) -> None:
                 log.debug(f"{proc.name()=}, {proc.pid=}, {pc=}")
                 if len(pc) > 0:
                     recurse(pc)
-                elif proc.name() in {"python", "python.exe"}:
+                    gone, alive = psutil.wait_procs(pc,timeout=10)
+                    log.debug(f"{gone=}")
+                    log.debug(f"{alive=}")
+                    rc = proc.wait(timeout=1)
+                    log.debug(f"{proc.name()=}, {proc.pid=}, {rc=}")
+                if proc.name() in {"python", "python.exe"}:
                     proc.terminate()
                     rc = proc.wait(timeout=1)
                     log.debug(f"{proc.name()=}, {proc.pid=}, {rc=}")

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -239,12 +239,16 @@ def cancel(args: Namespace) -> None:
         )
 
     def kill_tomato_job(proc):
+        log.warning(f"{proc.name()=}")
         for cp in proc.children():
+            log.warning(f" {cp.name()=}")
             if cp.name() in {"python", "python.exe"}:
-                for ccp in cp.children():
+                cpc = cp.children()
+                for ccp in cpc:
+                    log.warning(f"  {ccp.name()=}")
                     ccp.terminate()
                 gone, alive = psutil.wait_procs(
-                    cp,
+                    cpc,
                     timeout=3, 
                     callback=on_terminate
                 )

--- a/src/tomato/main.py
+++ b/src/tomato/main.py
@@ -164,6 +164,21 @@ def run_ketchup():
     )
     snapshot.set_defaults(func=ketchup.snapshot)
 
+    search = subparsers.add_parser("search")
+    search.add_argument(
+        "jobname", 
+        help="The jobname of the searched job.", 
+        default=None,
+    )
+    search.add_argument(
+        "-c",
+        "--complete",
+        action="store_true",
+        default=False,
+        help="Search also in completed jobs.",
+    )
+    search.set_defaults(func=ketchup.search)
+
     args, extras = parser.parse_known_args()
     args, extras = verbose.parse_known_args(extras, args)
     _logging_setup(args)

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -55,17 +55,28 @@ def test_run_dummy_random(casename, npoints, prefix, datadir):
 
 
 @pytest.mark.parametrize(
-    "casename, jobname",
+    "casename, jobname, search",
     [
         (
             "dummy_random_1_0.1",
             "custom_name",
+            False
+        ),
+        (
+            "dummy_random_30_1",
+            "$MATCH_custom_name",
+            True
         ),
     ],
 )
-def test_run_dummy_jobname(casename, jobname, datadir):
+def test_run_dummy_jobname(casename, jobname, search, datadir):
     os.chdir(datadir)
-    status = utils.run_casename(casename, jobname=jobname)
+    if search:
+        status = utils.run_casename(
+            casename, jobname=jobname, inter_func=utils.search_job
+        )
+    else:
+        status = utils.run_casename(casename, jobname=jobname)
     assert status == "c"
     ret = subprocess.run(
         ["ketchup", "-t", "status", "1"],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,7 +49,7 @@ def ketchup_setup(casename, jobname):
 
 
 def ketchup_loop(start, inter_func):
-    inter_exec = False
+    inter_exec = None
     end = False
     logger.debug("In 'ketchup_loop'.")
     while True:
@@ -76,7 +76,7 @@ def ketchup_loop(start, inter_func):
                 status = line.split("=")[1].strip()
                 if status.startswith("c"):
                     end = True
-                elif status.startswith("r"):
+                elif status.startswith("r") and inter_exec is None:
                     inter_exec = True
     return status
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,8 +15,10 @@ def run_casename(
     proc = subprocess.Popen(["tomato", "-t", "-vv"], creationflags=cfg)
     p = psutil.Process(pid=proc.pid)
     while not os.path.exists("database.db"):
-        time.sleep(1)
-
+        time.sleep(0.1)
+    
+    logger.debug("Sleeping before job submission.")
+    time.sleep(2)
     subprocess.run(["ketchup", "-t", "load", casename, "dummy-10", "-vv"])
     subprocess.run(["ketchup", "-t", "ready", "dummy-10", "-vv"])
     args = ["ketchup", "-t", "submit", f"{casename}.yml", "dummy-10", "-vv"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,3 +73,19 @@ def cancel_job(jobid: int = 1):
 def snapshot_job(jobid: int = 1):
     logger.debug("Running 'ketchup snapshot'.")
     subprocess.run(["ketchup", "-t", "snapshot", f"{jobid}", "-vv"])
+
+
+def search_job(jobid: int = 1):
+    logger.debug("Running 'ketchup search'.")
+    ret = subprocess.run(
+        ["ketchup", "-t", "search", "$MATCH", "-vv"],
+        capture_output=True,
+        text=True,
+    )
+    for line in ret.stdout.split("\n"):
+        if "jobname" in line:
+            assert "$MATCH" in line.split(":")[-1].strip()
+        elif "jobid" in line:
+            assert line.split(":")[-1].strip() == "1"
+        elif "status" in line:
+            assert line.split(":")[-1].strip() == "r"


### PR DESCRIPTION
Implements a new `ketchup search <jobname>` command, which searches the currently running/queued list of jobs for those that match the provided ``jobname``. An optional argument `-c` can enable searching in completed jobs too.