### PR TITLE
`ketchup status` changes

### DIFF
--- a/src/tomato/ketchup/__init__.py
+++ b/src/tomato/ketchup/__init__.py
@@ -9,6 +9,8 @@ Module of functions to interact with tomato. Includes job management functions:
 - :func:`.submit` to submit a *job* to *queue*
 - :func:`.status` to query the status of tomato's *pipelines*, its *queue*, or a *job*
 - :func:`.cancel` to cancel a queued or kill a running *job*
+- :func:`.snapshot` to create an up-to-date FAIR data archive of a running *job*
+- :func:`.search` to find a ``jobid`` of a *job* from ``jobname``
 
 Also includes *sample*/*pipeline* management functions:
 

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -37,23 +37,22 @@ def submit(args: Namespace) -> None:
 
     >>> # Submit a job:
     >>> ketchup submit .\dummy_random_2_0.1.yml
-    jobid = 2
+    jobid: 2
+    jobname: null
 
     >>> # Increased verbosity:
     >>> ketchup -v submit .\dummy_random_2_0.1.yml
     INFO:tomato.ketchup.functions:Output path not set. Setting output path to 'C:\[...]'
     INFO:tomato.ketchup.functions:queueing 'payload' into 'queue'
     INFO:tomato.dbhandler.sqlite:inserting a new job into 'state'
-    jobid = 4
+    jobid: 4
+    jobname: null
 
     >>> # With a job name:
     >>> ketchup submit .\dummy_random_2_0.1.yml -j dummy_random_2_0.1
-    jobid = 5
-    >>> ketchup status 5
-    jobid = 5
-    jobname = dummy_random_2_0.1
-    ...
-
+    jobid: 5
+    jobname: dummy_random_2_0.1
+    
     """
     dirs = setlib.get_dirs(args.test)
     settings = setlib.get_settings(dirs.user_config_dir, dirs.user_data_dir)
@@ -84,7 +83,8 @@ def submit(args: Namespace) -> None:
     jobid = dbhandler.queue_payload(
         queue["path"], pstr, type=queue["type"], jobname=args.jobname
     )
-    print(f"jobid = {jobid}")
+    print(f"jobid: {jobid}")
+    print(f"jobname: {'null' if args.jobname is None else args.jobname}")
 
 
 def status(args: Namespace) -> None:
@@ -128,14 +128,19 @@ def status(args: Namespace) -> None:
     3      None                 r      1035      dummy-10
     4      other_name           q
 
+    .. note::
+
+        Calling ``ketchup status`` with a single ``jobid`` will return a ``yaml``
+        :class:`list`, even though status of only one element was queried.
+
     >>> # Get status of a given job
     >>> ketchup status 1
-    jobid = 1
-    jobname = None
-    status  = c
-    submitted at = 2022-06-02 06:49:00.578619+00:00
-    executed at  = 2022-06-02 06:49:02.966775+00:00
-    completed at = 2022-06-02 06:49:08.229213+00:00
+    - jobid: 1
+      jobname: null
+      status:  c
+      submitted: 2022-06-02 06:49:00.578619+00:00
+      executed: 2022-06-02 06:49:02.966775+00:00
+      completed: 2022-06-02 06:49:08.229213+00:00
 
     """
     dirs = setlib.get_dirs(args.test)
@@ -143,7 +148,7 @@ def status(args: Namespace) -> None:
     state = settings["state"]
     queue = settings["queue"]
 
-    if args.jobid == "state":
+    if "state" in args.jobid:
         pips = dbhandler.pipeline_get_all(state["path"], type=state["type"])
         print(
             f"{'pipeline':20s} {'ready':5s} {'jobid':6s} {'(PID)':9s} {'sampleid':20s} "
@@ -156,7 +161,7 @@ def status(args: Namespace) -> None:
             rstr = "yes" if ready else "no"
             job = f"{str(jobid):6s} ({pid})" if jobid is not None else str(jobid)
             print(f"{pip:20s} {rstr:5s} {job:16s} {str(sampleid):20s}")
-    elif args.jobid == "queue":
+    elif "queue" in args.jobid:
         jobs = dbhandler.job_get_all(queue["path"], type=queue["type"])
         running = dbhandler.pipeline_get_running(state["path"], type=state["type"])
         print(
@@ -176,26 +181,33 @@ def status(args: Namespace) -> None:
             elif status.startswith("c") and args.verbose - args.quiet > 0:
                 print(f"{str(jobid):6s} {str(jobname):20s} {status:6s}")
     else:
-        jobid = int(args.jobid)
-        ji = dbhandler.job_get_info(queue["path"], jobid, type=queue["type"])
-        if ji is None:
-            log.error("job with jobid '%s' does not exist.", jobid)
-            return None
-        jobname, payload, status, submitted_at, executed_at, completed_at = ji
-        print(f"jobid = {jobid}")
-        print(f"jobname = {jobname}")
-        print(f"status  = {status}")
-        print(f"submitted at = {submitted_at}")
-        if status.startswith("r") or status.startswith("c"):
-            print(f"executed at  = {executed_at}")
-            running = dbhandler.pipeline_get_running(state["path"], type=state["type"])
-            for pipeline, pjobid, pid in running:
-                if pjobid == jobid:
-                    print(f"with pipeline = {pipeline}")
-                    print(f"with PID = {pid}")
-                    break
-        if status.startswith("c"):
-            print(f"completed at = {completed_at}")
+        for jobid in args.jobid:
+            try:
+                jobid = int(jobid)
+            except:
+                logging.error("could not parse provided jobid: '%s'", jobid)
+                return 1
+            ji = dbhandler.job_get_info(queue["path"], jobid, type=queue["type"])
+            if ji is None:
+                log.error("job with jobid '%s' does not exist.", jobid)
+                return None
+            jobname, payload, status, submitted_at, executed_at, completed_at = ji
+            print(f"- jobid: {jobid}")
+            print(f"  jobname: {'null' if jobname is None else jobname}")
+            print(f"  status: {status}")
+            print(f"  submitted: {submitted_at}")
+            if status.startswith("r") or status.startswith("c"):
+                print(f"  executed: {executed_at}")
+                running = dbhandler.pipeline_get_running(
+                    state["path"], type=state["type"]
+                )
+                for pipeline, pjobid, pid in running:
+                    if pjobid == jobid:
+                        print(f"  pipeline: {pipeline}")
+                        print(f"  pid: {pid}")
+                        break
+            if status.startswith("c"):
+                print(f"  completed: {completed_at}")
 
 
 def cancel(args: Namespace) -> None:
@@ -452,18 +464,14 @@ def search(args: Namespace) -> None:
     job status and ``jobid``. If the option ``-c/--complete`` is specified,
     the completed jobs will also be searched.
 
-    .. note::
-
-        Output of ``ketchup search`` is a valid ``yaml``.
-
     Examples
     --------
 
     >>> # Create a snapshot in current working directory:
     >>> ketchup submit .\dummy_random_2_0.1.yml -j dummy_random_2_0.1
     >>> ketchup search dummy_random_2
-    - jobname: dummy_random_2_0.1
-      jobid: 1
+    - jobid: 1
+      jobname: dummy_random_2_0.1
       status: r
 
     """
@@ -475,6 +483,6 @@ def search(args: Namespace) -> None:
     for jobid, jobname, payload, status in alljobs:
         if jobname is not None and args.jobname in jobname:
             if args.complete or not status.startswith("c"):
-                print(f"- jobname: {jobname}")
-                print(f"  jobid: {jobid}")
+                print(f"- jobid: {jobid}")
+                print(f"  jobname: {jobname}")
                 print(f"  status: {status}")

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -52,7 +52,7 @@ def submit(args: Namespace) -> None:
     >>> ketchup submit .\dummy_random_2_0.1.yml -j dummy_random_2_0.1
     jobid: 5
     jobname: dummy_random_2_0.1
-    
+
     """
     dirs = setlib.get_dirs(args.test)
     settings = setlib.get_settings(dirs.user_config_dir, dirs.user_data_dir)

--- a/src/tomato/main.py
+++ b/src/tomato/main.py
@@ -127,13 +127,13 @@ def run_ketchup():
     status = subparsers.add_parser("status")
     status.add_argument(
         "jobid",
-        nargs="?",
+        nargs="*",
         help=(
             "The jobid of the requested job, "
             "or 'queue' for the status of the queue,"
             "or 'state' for the status of pipelines."
         ),
-        default="state",
+        default=["state"],
     )
     status.set_defaults(func=ketchup.status)
 

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -2,6 +2,7 @@ import pytest
 import json
 import os
 import subprocess
+import yaml
 
 from . import utils
 
@@ -108,3 +109,21 @@ def test_run_dummy_snapshot(casename, external, datadir):
     assert status == "c"
     assert os.path.exists("snapshot.1.json")
     assert os.path.exists("snapshot.1.zip")
+
+
+def test_run_dummy_multiple(datadir):
+    os.chdir(datadir)
+    casenames = ["dummy_random_5_2", "dummy_random_1_0.1"]
+    jobnames = ["job one", "job two"]
+    utils.run_casename(casename = casenames, jobname = jobnames)
+    ret = subprocess.run(
+        ["ketchup", "-t", "status", "1", "2"],
+        capture_output=True,
+        text=True,
+    )
+    yml = yaml.safe_load(ret.stdout)
+    assert len(yml) == 2
+    assert {1, 2} == set([i["jobid"] for i in yml])
+    assert set(jobnames) == set([i["jobname"] for i in yml])
+    assert {"c"} == set([i["status"] for i in yml])
+    

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -115,7 +115,7 @@ def test_run_dummy_multiple(datadir):
     os.chdir(datadir)
     casenames = ["dummy_random_5_2", "dummy_random_1_0.1"]
     jobnames = ["job one", "job two"]
-    utils.run_casename(casename = casenames, jobname = jobnames)
+    utils.run_casename(casename=casenames, jobname=jobnames)
     ret = subprocess.run(
         ["ketchup", "-t", "status", "1", "2"],
         capture_output=True,
@@ -126,4 +126,3 @@ def test_run_dummy_multiple(datadir):
     assert {1, 2} == set([i["jobid"] for i in yml])
     assert set(jobnames) == set([i["jobname"] for i in yml])
     assert {"c"} == set([i["status"] for i in yml])
-    

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,8 +3,9 @@ import time
 import psutil
 import signal
 import os
+import yaml
 import logging
-from typing import Callable
+from typing import Callable, Union, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -39,14 +40,15 @@ def tomato_setup():
     return proc, p
 
 
-def ketchup_setup(casename, jobname):
+def ketchup_setup(casename, jobname, pip = "dummy-10"):
     logger.debug("In 'ketchup_setup'.")
-    subprocess.run(["ketchup", "-t", "load", casename, "dummy-10", "-vv"])
-    subprocess.run(["ketchup", "-t", "ready", "dummy-10", "-vv"])
-    args = ["ketchup", "-t", "submit", f"{casename}.yml", "dummy-10", "-vv"]
+    subprocess.run(["ketchup", "-t", "load", casename, pip, "-vv"])
+    subprocess.run(["ketchup", "-t", "ready", pip, "-vv"])
+    args = ["ketchup", "-t", "submit", f"{casename}.yml", "-vv"]
     if jobname is not None:
         args.append("--jobname")
         args.append(jobname)
+    print(args)
     subprocess.run(args)
 
 
@@ -74,13 +76,13 @@ def ketchup_loop(start, inter_func):
             capture_output=True,
             text=True,
         )
-        for line in ret.stdout.split("\n"):
-            if line.startswith("status"):
-                status = line.split("=")[1].strip()
-                if status.startswith("c"):
-                    end = True
-                elif status.startswith("r") and inter_exec is None:
-                    inter_exec = True
+        yml = yaml.safe_load(ret.stdout)
+        assert len(yml) == 1
+        status = yml[0]["status"]
+        if status.startswith("c"):
+            end = True
+        elif status.startswith("r") and inter_exec is None:
+            inter_exec = True
     return status
 
 
@@ -92,12 +94,20 @@ def ketchup_kill(proc, p):
 
 
 def run_casename(
-    casename: str,
-    jobname: str = None,
+    casename: Union[str, list[str]],
+    jobname: Union[str, list[str]] = None,
     inter_func: Callable = None,
 ) -> str:
     proc, p = tomato_setup()
-    ketchup_setup(casename, jobname)
+    if isinstance(casename, str):
+        ketchup_setup(casename, jobname)
+    elif isinstance(casename, Sequence):
+        pnames = ["dummy-10", "dummy-5"]
+        for idx, tup in enumerate(zip(casename, jobname)):
+            cn, jn = tup
+            pn = pnames[idx]
+            print(f"{cn=}, {jn=}, {pn=}")
+            ketchup_setup(cn, jn, pip=pn)
     status = ketchup_loop(time.perf_counter(), inter_func)
     ketchup_kill(proc, p)
     return status

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,7 +40,7 @@ def tomato_setup():
     return proc, p
 
 
-def ketchup_setup(casename, jobname, pip = "dummy-10"):
+def ketchup_setup(casename, jobname, pip="dummy-10"):
     logger.debug("In 'ketchup_setup'.")
     subprocess.run(["ketchup", "-t", "load", casename, pip, "-vv"])
     subprocess.run(["ketchup", "-t", "ready", pip, "-vv"])


### PR DESCRIPTION
This PR closes #32:

- [x] `ketchup status <jobid>` accepts multiple jobids both as a comma- or space-separated list
- [x] `ketchup status <jobid>` returns a `yaml` list of job info
- [x] `ketchup submit <jobfile>` returns a single `yaml` job info
- [x] `ketchup search <jobname>` returns a `yaml` list of job info 