### PR TITLE
`ketchup.cancel`: Implement new cancel mechanism.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -31,13 +31,6 @@ single experimental *payload*.
     For instructions on how to set **tomato** up for a first run, see the :ref:`quickstart`.
 
 
-.. warning::
-
-    Currently, all *jobs* are executed under the user that started the :mod:`tomato.daemon`.
-    This means that when the :mod:`tomato.daemon` is running under a different user than the 
-    current user who submits a *job*, this current user (if unpriviledged) will not be able to 
-    cancel their own *job*.
-
 Using :mod:`~tomato.ketchup`
 ````````````````````````````
 
@@ -78,6 +71,7 @@ by loading or ejecting *samples* and marking *pipelines* ready for execution.
            q     Job has entered the queue.
            qw    Job is in the queue, waiting for a pipeline to be ready.
            r     Job is running.
+           rd    Job has been marked for cancellation.
            c     Job has completed successfully.
            ce    Job has completed with an error.
            cd    Job has been cancelled.
@@ -93,6 +87,9 @@ by loading or ejecting *samples* and marking *pipelines* ready for execution.
         .. code-block:: bash
 
             >>> ketchup cancel <jobid>
+
+        This will mark the `job` for cancellation by setting its status to ``rd``. The
+        :mod:`tomato.daemon` will then proceed with cancelling the `job`.
 
 *Jobs* submitted to the *queue* will remain in the *queue* until a *pipeline* meets all
 of the following criteria:

--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -8,25 +8,26 @@ from .. import dbhandler
 
 log = logging.getLogger(__name__)
 
+
 def _kill_tomato_job(proc):
-        pc = proc.children()
-        log.warning(f"{proc.name()=}, {proc.pid=}, {pc=}")
-        if psutil.WINDOWS:
-            for proc in pc:
-                if proc.name() in {"conhost.exe"}:
-                    continue
-                ppc = proc.children()
-                for proc in ppc:
-                    log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
-                    proc.terminate()
-                gone, alive = psutil.wait_procs(ppc, timeout=10)
-        elif psutil.POSIX:
-            for proc in pc:
+    pc = proc.children()
+    log.warning(f"{proc.name()=}, {proc.pid=}, {pc=}")
+    if psutil.WINDOWS:
+        for proc in pc:
+            if proc.name() in {"conhost.exe"}:
+                continue
+            ppc = proc.children()
+            for proc in ppc:
                 log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
                 proc.terminate()
-            gone, alive = psutil.wait_procs(pc, timeout=10)
-        log.debug(f"{gone=}")
-        log.debug(f"{alive=}")
+            gone, alive = psutil.wait_procs(ppc, timeout=10)
+    elif psutil.POSIX:
+        for proc in pc:
+            log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
+            proc.terminate()
+        gone, alive = psutil.wait_procs(pc, timeout=10)
+    log.debug(f"{gone=}")
+    log.debug(f"{alive=}")
 
 
 def _find_matching_pipelines(pipelines: list, method: list[dict]) -> list[str]:

--- a/src/tomato/dbhandler/sqlite.py
+++ b/src/tomato/dbhandler/sqlite.py
@@ -14,7 +14,7 @@ def get_db_conn(
         sql = sqlite3
     else:
         raise RuntimeError(f"database type '{type}' unsupported")
-    
+
     head, tail = os.path.split(dbpath)
     if head != "" and not os.path.exists(head):
         log.warning("making local data folder '%s'", head)

--- a/src/tomato/drivers/dummy/main.py
+++ b/src/tomato/drivers/dummy/main.py
@@ -139,7 +139,7 @@ def start_job(
 
     jobqueue
         :class:`multiprocessing.Queue` for passing job related data.
-    
+
     logger
         :class:`logging.Logger` instance for writing logs.
 

--- a/src/tomato/ketchup/functions.py
+++ b/src/tomato/ketchup/functions.py
@@ -229,7 +229,9 @@ def cancel(args: Namespace) -> None:
 
     .. note::
 
-        The :func:`~ketchup.functions.cancel` onl
+        The :func:`~ketchup.functions.cancel` only sets the status of the running
+        job to ``rd``; the actual job cancellation is performed in the
+        :func:`tomato.daemon.main.main_loop`.
 
     Examples
     --------


### PR DESCRIPTION
Implement a job cancellation mechanism where `ketchup` only marks the job for deletion, and `tomato.daemon.main_loop` actually kills the job. This should let users cancel jobs even if `tomato` is running under a different user.