### PR TITLE
Fix crash when `ketchup cancel` is used

### DIFF
--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -18,13 +18,19 @@ def _kill_tomato_job(proc):
                 continue
             ppc = proc.children()
             for proc in ppc:
-                log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
-                proc.terminate()
+                try:
+                    log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
+                    proc.terminate()
+                except psutil.NoSuchProcess:
+                    continue
             gone, alive = psutil.wait_procs(ppc, timeout=10)
     elif psutil.POSIX:
         for proc in pc:
-            log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
-            proc.terminate()
+            try:
+                log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
+                proc.terminate()
+            except psutil.NoSuchProcess:
+                continue
         gone, alive = psutil.wait_procs(pc, timeout=10)
     log.debug(f"{gone=}")
     log.debug(f"{alive=}")

--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -22,6 +22,10 @@ def _kill_tomato_job(proc):
                     log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
                     proc.terminate()
                 except psutil.NoSuchProcess:
+                    log.warning(
+                         "dead process: "
+                        f"{proc.name()=}, {proc.pid=}, {proc.children()=}"
+                    )
                     continue
             gone, alive = psutil.wait_procs(ppc, timeout=10)
     elif psutil.POSIX:

--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -69,6 +69,7 @@ def _pipeline_ready_sample(ret: tuple, sample: dict) -> bool:
 
 
 def main_loop(settings: dict, pipelines: dict, test: bool = False) -> None:
+    log.info("Entered 'main_loop'.")
     qup = settings["queue"]["path"]
     qut = settings["queue"]["type"]
     stp = settings["state"]["path"]

--- a/src/tomato/daemon/main.py
+++ b/src/tomato/daemon/main.py
@@ -11,7 +11,9 @@ log = logging.getLogger(__name__)
 
 def _kill_tomato_job(proc):
     pc = proc.children()
-    log.warning(f"{proc.name()=}, {proc.pid=}, {pc=}")
+    log.warning(
+        "killing proc: name='%s', pid=%d, children=%d", proc.name(), proc.pid, len(pc)
+    )
     if psutil.WINDOWS:
         for proc in pc:
             if proc.name() in {"conhost.exe"}:
@@ -19,21 +21,21 @@ def _kill_tomato_job(proc):
             ppc = proc.children()
             for proc in ppc:
                 try:
-                    log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
                     proc.terminate()
                 except psutil.NoSuchProcess:
                     log.warning(
-                         "dead process: "
-                        f"{proc.name()=}, {proc.pid=}, {proc.children()=}"
+                        "dead proc: name='%s', pid=%d", proc.name(), proc.pid
                     )
                     continue
             gone, alive = psutil.wait_procs(ppc, timeout=10)
     elif psutil.POSIX:
         for proc in pc:
             try:
-                log.debug(f"{proc.name()=}, {proc.pid=}, {proc.children()=}")
                 proc.terminate()
             except psutil.NoSuchProcess:
+                log.warning(
+                    "dead proc: name='%s', pid=%d", proc.name(), proc.pid
+                )
                 continue
         gone, alive = psutil.wait_procs(pc, timeout=10)
     log.debug(f"{gone=}")

--- a/src/tomato/main.py
+++ b/src/tomato/main.py
@@ -83,9 +83,8 @@ def run_tomato():
     elif psutil.POSIX:
         pid = os.getpid()
 
-    toms = [
-        p.pid for p in psutil.process_iter() if p.name() in {"tomato", "tomato.exe"}
-    ]
+    procs = psutil.process_iter(['pid', 'name'])
+    toms = [p.pid for p in procs if p.name() in {"tomato", "tomato.exe"}]
     toms.pop(toms.index(pid))
     if len(toms) > 0 and not args.test:
         logging.critical("cannot run more than one instance of 'tomato'")


### PR DESCRIPTION
In some cases, the child processes may be already killed - this patch excepts that case and prints a warning.