### PR TITLE
Fix tomato disconnection issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         "toml",
         "pyyaml",
         "psutil",
-        "yadg>=4.2<5.0",
+        "yadg>=4.2.4,<5.0",
         "dgbowl_schemas>=108",
         "filelock",
     ],

--- a/src/tomato/drivers/biologic/main.py
+++ b/src/tomato/drivers/biologic/main.py
@@ -10,6 +10,86 @@ from .kbio_wrapper import (
     get_kbio_api,
 )
 
+def safe_api_connect(api,
+                    address: str,
+                    retries: int = 100,
+                    timeout: int = 10
+                    ) -> tuple:
+    """
+    Attempt to establish a connection with the device, retrying if necessary.
+
+    This function attempts to connect to the device at the specified address.
+    If the connection attempt fails, it retries up to a specified number of times,
+    waiting for a specified timeout period between each attempt.
+
+    Parameters
+    ----------
+    api
+        The API object used for making the connection.
+    address : str
+        The IP address of the device to connect to.
+    retries : int, optional
+        The number of times to retry the connection attempt. Default is 100.
+    timeout : int, optional
+        The time in seconds to wait between retries. Default is 10.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the ID and device information upon successful connection.
+
+    Raises
+    ------
+    Exception
+        If the function fails to connect after the specified number of retries.
+
+    """
+    for _ in range(retries):
+        try:
+            id_, device_info = api.Connect(address)
+            return id_, device_info
+        except Exception as e:
+            time.sleep(timeout)
+    raise Exception(f"Failed to connect after {retries} retries")
+
+
+def safe_api_disconnect(api,
+                        id_,
+                        retries: int = 100,
+                        timeout: int = 10):
+    """
+    Attempt to disconnect from the device, retrying if necessary.
+
+    This function attempts to disconnect from the device using the provided ID.
+    If the disconnection attempt fails, it retries up to a specified number of times,
+    waiting for a specified timeout period between each attempt.
+
+    Parameters
+    ----------
+    api
+        The API object used for disconnecting.
+    id_
+        The ID of the device to disconnect from.
+    retries : int, optional
+        The number of times to retry the disconnection attempt. Default is 100.
+    timeout : int, optional
+        The time in seconds to wait between retries. Default is 10.
+
+    Raises
+    ------
+    Exception
+        If the function fails to disconnect after the specified number of retries.
+
+    """
+    for _ in range(retries):
+        try:
+            api.Disconnect(id_)
+            return
+        except Exception as e:
+            time.sleep(timeout)
+    raise Exception(f"Failed to disconnect after {retries} retries")
+
+
 
 def get_status(
     address: str,
@@ -19,7 +99,7 @@ def get_status(
     dllpath: str = None,
     lockpath: str = None,
     **kwargs: dict,
-) -> tuple[float, dict]:
+    ) -> tuple[float, dict]:
     """
     Get the current status of the device.
 
@@ -39,7 +119,6 @@ def get_status(
     timestamp, ready, metadata: tuple[float, bool, dict]
         Returns a tuple containing the timestamp, readiness status, and
         associated metadata.
-
     """
     api = get_kbio_api(dllpath)
     metadata = {}
@@ -47,13 +126,14 @@ def get_status(
     with FileLock(lockpath, timeout=60) as fh:
         try:
             logger.info(f"connecting to '{address}:{channel}'")
-            id_, device_info = api.Connect(address)
+            id_, device_info = safe_api_connect(api, address)
             logger.info(f"getting status of '{address}:{channel}'")
             channel_info = api.GetChannelInfo(id_, channel)
             logger.info(f"disconnecting from '{address}:{channel}'")
-            api.Disconnect(id_)
+            safe_api_disconnect(api, id_)
         except Exception as e:
             logger.critical(f"{e=}")
+            raise
     metadata["device_model"] = device_info.model
     metadata["device_channels"] = device_info.NumberOfChannels
     metadata["channel_state"] = channel_info.state
@@ -70,7 +150,6 @@ def get_status(
     dt = datetime.now(timezone.utc)
     return dt.timestamp(), ready, metadata
 
-
 def get_data(
     address: str,
     channel: int,
@@ -79,7 +158,7 @@ def get_data(
     dllpath: str = None,
     lockpath: str = None,
     **kwargs: dict,
-) -> tuple[float, dict]:
+    ) -> tuple[float, dict]:
     """
     Get cached data from the device.
 
@@ -104,17 +183,17 @@ def get_data(
     with FileLock(lockpath, timeout=60) as fh:
         try:
             logger.info(f"connecting to '{address}:{channel}'")
-            id_, device_info = api.Connect(address)
+            id_, device_info = safe_api_connect(api, address)
             logger.info(f"getting data from '{address}:{channel}'")
             data = api.GetData(id_, channel)
             logger.info(f"disconnecting from '{address}:{channel}'")
-            api.Disconnect(id_)
+            safe_api_disconnect(api, id_)
         except Exception as e:
             logger.critical(f"{e=}")
+            raise
     dt = datetime.now(timezone.utc)
     data = parse_raw_data(api, data, device_info.model)
     return dt.timestamp(), data["technique"]["data_rows"], data
-
 
 def start_job(
     address: str,
@@ -126,7 +205,7 @@ def start_job(
     lockpath: str = None,
     capacity: float = 0.0,
     **kwargs: dict,
-) -> float:
+    ) -> float:
     """
     Start a job on the device.
 
@@ -158,7 +237,6 @@ def start_job(
     -------
     timestamp
         A timestamp corresponding to the start of the job execution.
-
     """
     api = get_kbio_api(dllpath)
     logger.debug("translating payload to ECC")
@@ -170,7 +248,7 @@ def start_job(
             last = False
             ti = 1
             logger.info(f"connecting to '{address}:{channel}'")
-            id_, device_info = api.Connect(address)
+            id_, device_info = safe_api_connect(api, address)
             for techname, pars in eccpars:
                 if ti == ntechs:
                     last = True
@@ -184,13 +262,13 @@ def start_job(
             logger.info(f"starting run on '{address}:{channel}'")
             api.StartChannel(id_, channel)
             logger.info(f"disconnecting from '{address}:{channel}'")
-            api.Disconnect(id_)
+            safe_api_disconnect(api, id_)
         except Exception as e:
             logger.critical(f"{e=}")
+            raise
     dt = datetime.now(timezone.utc)
     logger.info(f"run started at '{dt}'")
     return dt.timestamp()
-
 
 def stop_job(
     address: str,
@@ -200,7 +278,7 @@ def stop_job(
     dllpath: str = None,
     lockpath: str = None,
     **kwargs: dict,
-) -> float:
+    ) -> float:
     """
     Stop a job running on the device.
 
@@ -222,19 +300,19 @@ def stop_job(
     -------
     timestamp
         A timestamp corresponding to the start of the job execution.
-
     """
     api = get_kbio_api(dllpath)
     with FileLock(lockpath, timeout=60) as fh:
         try:
             logger.info(f"connecting to '{address}:{channel}'")
-            id_, device_info = api.Connect(address)
+            id_, device_info = safe_api_connect(api, address)
             logger.info(f"stopping run on '{address}:{channel}'")
             api.StopChannel(id_, channel)
             logger.info(f"run stopped at '{dt}'")
-            api.Disconnect(id_)
+            safe_api_disconnect(api, id_)
         except Exception as e:
             logger.critical(f"{e=}")
+            raise
     if jobqueue:
         jobqueue.close()
     else:

--- a/src/tomato/drivers/biologic/main.py
+++ b/src/tomato/drivers/biologic/main.py
@@ -2,9 +2,7 @@ import logging
 import multiprocessing
 import time
 from filelock import FileLock
-
 from datetime import datetime, timezone
-
 from .kbio_wrapper import (
     get_kbio_techpath,
     payload_to_ecc,


### PR DESCRIPTION
__Summary__
- Replace api.connect originally used in the script with safe_api_connect and safe_api_disconnect function. 
- The two functions is made by wrapping api.Connect and api.Disconnect in a try/except loop. Instead of try api.Connect or api.disconnect once, this wrapper function will try to connect/disconnect for 100 times with 10 seconds wait between trial, before rasing an exception. 