### PR TITLE
Reliable tests

### DIFF
--- a/tests/test_01_tomato.py
+++ b/tests/test_01_tomato.py
@@ -140,13 +140,13 @@ def test_tomato_log_verbosity_0(datadir, stop_tomato_daemon):
 
 
 def test_tomato_log_verbosity_default(start_tomato_daemon, stop_tomato_daemon):
-    assert wait_until_tomato_running(**kwargs).success
+    assert wait_until_tomato_running(port=PORT, timeout=5000)
     assert Path("daemon_12345.log").exists()
     assert Path("daemon_12345.log").stat().st_size > 0
 
 
 def test_tomato_nocmd(start_tomato_daemon, stop_tomato_daemon):
-    assert wait_until_tomato_running(**kwargs).success
+    assert wait_until_tomato_running(port=PORT, timeout=5000)
     req = CTXT.socket(zmq.REQ)
     req.connect("tcp://127.0.0.1:12345")
     req.send_pyobj(dict(cdm="typo"))

--- a/tests/test_01_tomato.py
+++ b/tests/test_01_tomato.py
@@ -5,6 +5,7 @@ import yaml
 import zmq
 
 from tomato import tomato
+from .utils import wait_until_tomato_running
 
 PORT = 12345
 CTXT = zmq.Context()
@@ -139,13 +140,14 @@ def test_tomato_log_verbosity_0(datadir, stop_tomato_daemon):
 
 
 def test_tomato_log_verbosity_default(start_tomato_daemon, stop_tomato_daemon):
+    assert wait_until_tomato_running(**kwargs).success
     assert Path("daemon_12345.log").exists()
     assert Path("daemon_12345.log").stat().st_size > 0
 
 
 def test_tomato_nocmd(start_tomato_daemon, stop_tomato_daemon):
-    context = zmq.Context()
-    req = context.socket(zmq.REQ)
+    assert wait_until_tomato_running(**kwargs).success
+    req = CTXT.socket(zmq.REQ)
     req.connect("tcp://127.0.0.1:12345")
     req.send_pyobj(dict(cdm="typo"))
     rep = req.recv_pyobj()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,8 @@ import yaml
 import logging
 from typing import Callable, Union, Sequence
 import psutil
+import zmq
+from tomato import tomato
 
 logger = logging.getLogger(__name__)
 
@@ -182,3 +184,12 @@ def job_status(jobid):
     )
     yml = yaml.safe_load(ret.stdout)
     return yml
+
+
+def wait_until_tomato_running(port: int, timeout: int, context: zmq.Context):
+    t0 = time.perf_counter()
+    while time.perf_counter() - t0 < timeout:
+        ret = tomato.status(port=port, timeout=1000, context=context)
+        if ret.success:
+            return ret
+    return ret

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,168 +1,13 @@
 import subprocess
 import time
-import signal
-import os
 import yaml
 import logging
-from typing import Callable, Union, Sequence
-import psutil
 
 logger = logging.getLogger(__name__)
 
 
-def tomato_setup():
-    cmd = ["tomato", "init", "--datadir", ".", "--appdir", "."]
-    subprocess.Popen(cmd)
-    cmd = ["tomato", "start", "-p", "12345", "--appdir", ".", "--logdir", "."]
-    if psutil.WINDOWS:
-        cfg = subprocess.CREATE_NEW_PROCESS_GROUP
-        proc = subprocess.Popen(cmd, creationflags=cfg)
-    elif psutil.POSIX:
-        proc = subprocess.Popen(cmd, start_new_session=True)
-    p = psutil.Process(pid=proc.pid)
-    count = 0
-    while True:
-        ret = subprocess.run(
-            ["tomato", "status", "--port", "12345"],
-            capture_output=True,
-            text=True,
-        )
-        ret = yaml.safe_load(ret.stdout)
-        print(f"{ret=}")
-        if ret["success"] and ret["data"]["status"] == "running":
-            break
-        else:
-            time.sleep(0.1)
-            count += 1
-            assert count < 20
-    return proc, p
-
-
-def sample_setup(casename, jobname, pip="dummy-10"):
-    logger.debug("In 'ketchup_setup'.")
-    subprocess.run(
-        ["tomato", "pipeline", "load", "-p", "12345", "--appdir", ".", pip, casename]
-    )
-    subprocess.run(["tomato", "pipeline", "ready", "-p", "12345", "--appdir", ".", pip])
-    args = ["ketchup", "submit", "-p", "12345", "--appdir", ".", f"{casename}.yml"]
-    if jobname is not None:
-        args.append("--jobname")
-        args.append(jobname)
-    subprocess.run(args)
-
-
-def ketchup_loop(start, inter_func):
-    print("In ketchup_loop")
-    inter_exec = None
-    end = False
-    while True:
-        time.sleep(1)
-        dt = time.perf_counter() - start
-        if end:
-            logger.debug("Job complete in %d s. ", dt)
-            break
-        if dt > 30:
-            logger.warning("Job took more than 120 s. Aborting...")
-            break
-        if not os.path.exists(os.path.join("Jobs", "1", "jobdata.log")):
-            continue
-        if inter_exec and inter_func is not None:
-            print("Running 'inter_func()'")
-            inter_func()
-            inter_exec = False
-        ret = subprocess.run(
-            [
-                "ketchup",
-                "status",
-                "-p",
-                "12345",
-                "--appdir",
-                ".",
-                "--datadir",
-                ".",
-                "1",
-            ],
-            capture_output=True,
-            text=True,
-        )
-        print(f"{ret.stdout}")
-        yml = yaml.safe_load(f"{ret.stdout}")
-        if yml["success"]:
-            status = yml["data"][0]["status"]
-            if status.startswith("c"):
-                end = True
-            elif status.startswith("r") and inter_exec is None:
-                inter_exec = True
-    return status
-
-
-def ketchup_kill(proc, p):
-    logger.debug("In 'ketchup_kill'.")
-    for cp in p.children():
-        cp.send_signal(signal.SIGTERM)
-    proc.terminate()
-
-
-def run_casename(
-    casename: Union[str, list[str]],
-    jobname: Union[str, list[str]] = None,
-    inter_func: Callable = None,
-) -> str:
-    print("tomato_setup()")
-    # proc, p = tomato_setup()
-    if isinstance(casename, str):
-        print("sample_setup()")
-        sample_setup(casename, jobname)
-    elif isinstance(casename, Sequence):
-        pnames = ["dummy-10", "dummy-5"]
-        for idx, tup in enumerate(zip(casename, jobname)):
-            cn, jn = tup
-            pn = pnames[idx]
-            sample_setup(cn, jn, pip=pn)
-    print("ketchup_loop()")
-    status = ketchup_loop(time.perf_counter(), inter_func)
-    print("ketchup_kill()")
-    ketchup_kill(proc, p)
-    return status
-
-
-def cancel_job(jobid: int = 1):
-    print("Running 'ketchup cancel'.")
-    subprocess.run(["ketchup", "cancel", "-p", "12345", "--appdir", ".", str(jobid)])
-
-
-def snapshot_job(jobid: int = 1):
-    print("Running 'ketchup snapshot'.")
-    subprocess.run(["ketchup", "snapshot", "-p", "12345", "--appdir", ".", f"{jobid}"])
-
-
-def search_job(jobname: str = "$MATCH"):
-    logger.debug("Running 'ketchup search'.")
-    ret = subprocess.run(
-        ["ketchup", "search", "-p", "12345", "--appdir", ".", jobname],
-        capture_output=True,
-        text=True,
-    )
-    for line in ret.stdout.split("\n"):
-        if "jobname" in line:
-            assert jobname in line.split(":")[-1].strip()
-        elif "jobid" in line:
-            assert line.split(":")[-1].strip() == "1"
-        elif "status" in line:
-            assert line.split(":")[-1].strip() == "r"
-
-
-if __name__ == "__main__":
-    logging.basicConfig(level=50)
-    status = run_casename("dummy_random_1_0.1")
-    print(f"{status=}")
-
-
 def run_casenames(
-    casenames: list[str],
-    jobnames: list[str],
-    pipelines: list[str],
-    inter_func: Callable = None,
+    casenames: list[str], jobnames: list[str], pipelines: list[str]
 ) -> str:
     for cn, jn, pip in zip(casenames, jobnames, pipelines):
         subprocess.run(["tomato", "pipeline", "load", "-p", "12345", pip, cn])
@@ -200,12 +45,7 @@ def wait_until_tomato_running(port: int, timeout: int):
     return False
 
 
-def wait_until_ketchup_status(
-    jobid: int,
-    status: str,
-    port: int,
-    timeout: int,
-):
+def wait_until_ketchup_status(jobid: int, status: str, port: int, timeout: int):
     t0 = time.perf_counter()
     while (time.perf_counter() - t0) < (timeout / 1000):
         ret = subprocess.run(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,8 +6,6 @@ import yaml
 import logging
 from typing import Callable, Union, Sequence
 import psutil
-import zmq
-from tomato import tomato, ketchup
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +194,7 @@ def wait_until_tomato_running(port: int, timeout: int):
         )
         data = yaml.safe_load(ret.stdout)
         if data["success"]:
-           return True
+            return True
         print(f"{data=}")
         time.sleep(timeout / 20000)
     return False
@@ -217,7 +215,7 @@ def wait_until_ketchup_status(
         )
         data = yaml.safe_load(ret.stdout)["data"]
         if data[jobid]["status"] == status:
-           return True
+            return True
         print(f"{data=}")
         time.sleep(timeout / 20000)
     return False


### PR DESCRIPTION
Replace `time.sleep()` in most tests with functions in `.utils`.