### PR TITLE
Pass verbosity of `tomato-daemon` to child processes

### DIFF
--- a/src/tomato/daemon/job.py
+++ b/src/tomato/daemon/job.py
@@ -197,7 +197,14 @@ def action_queued_jobs(daemon, matched, req):
             with jpath.open("w", encoding="UTF-8") as of:
                 json.dump(jobargs, of, indent=1)
 
-            cmd = ["tomato-job", "--port", str(daemon.port), str(jpath)]
+            cmd = [
+                "tomato-job",
+                "--port",
+                str(daemon.port),
+                "--verbosity",
+                str(daemon.verbosity),
+                str(jpath),
+            ]
             if psutil.WINDOWS:
                 cfs = subprocess.CREATE_NO_WINDOW
                 cfs |= subprocess.CREATE_NEW_PROCESS_GROUP
@@ -304,6 +311,12 @@ def tomato_job() -> None:
         type=int,
     )
     parser.add_argument(
+        "--verbosity",
+        help="Verbosity of the tomato-job.",
+        default=logging.INFO,
+        type=int,
+    )
+    parser.add_argument(
         "jobfile",
         type=Path,
         help="Path to a ketchup-processed payload json file.",
@@ -320,7 +333,7 @@ def tomato_job() -> None:
 
     logpath = jobpath / f"job-{jobid}.log"
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=args.verbosity,
         format="%(asctime)s - %(levelname)8s - %(name)-30s - %(message)s",
         handlers=[logging.FileHandler(logpath, mode="a")],
     )
@@ -407,11 +420,11 @@ def job_thread(
     Stores the data for that Component as a `pickle` of a :class:`xr.Dataset`.
     """
     sender = f"{__name__}.job_thread"
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format="%(asctime)s - %(levelname)8s - %(name)-30s - %(message)s",
-        handlers=[logging.FileHandler(logpath, mode="a")],
-    )
+    # logging.basicConfig(
+    #    level=logging.DEBUG,
+    #    format="%(asctime)s - %(levelname)8s - %(name)-30s - %(message)s",
+    #    handlers=[logging.FileHandler(logpath, mode="a")],
+    # )
     logger = logging.getLogger(sender)
     logger.debug(f"in job thread of {component.role!r}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def start_tomato_daemon(tmpdir: str, port: int = 12345):
     # setup_stuff
     os.chdir(tmpdir)
     subprocess.run(["tomato", "init", "-p", f"{port}", "-A", ".", "-D", "."])
-    subprocess.run(["tomato", "start", "-p", f"{port}", "-A", ".", "-L", ".", "-vv"])
+    subprocess.run(["tomato", "start", "-p", f"{port}", "-A", ".", "-L", ".", "-VV"])
     yield
     # teardown_stuff
 

--- a/tests/test_01_tomato.py
+++ b/tests/test_01_tomato.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import yaml
 import zmq
+import subprocess
 
 from tomato import tomato
 from .utils import wait_until_tomato_running, wait_until_tomato_stopped
@@ -155,7 +156,16 @@ def test_tomato_log_verbosity_0(datadir, stop_tomato_daemon):
     assert Path("daemon_12345.log").stat().st_size > 0
 
 
-def test_tomato_log_verbosity_default(start_tomato_daemon, stop_tomato_daemon):
+def test_tomato_log_verbosity_testing(datadir, start_tomato_daemon, stop_tomato_daemon):
+    assert wait_until_tomato_running(port=PORT, timeout=5000)
+    assert Path("daemon_12345.log").exists()
+    assert Path("daemon_12345.log").stat().st_size > 0
+
+
+def test_tomato_log_verbosity_default(datadir, stop_tomato_daemon):
+    os.chdir(datadir)
+    subprocess.run(["tomato", "init", "-p", f"{PORT}", "-A", ".", "-D", "."])
+    subprocess.run(["tomato", "start", "-p", f"{PORT}", "-A", ".", "-L", "."])
     assert wait_until_tomato_running(port=PORT, timeout=5000)
     assert Path("daemon_12345.log").exists()
     assert Path("daemon_12345.log").stat().st_size > 0


### PR DESCRIPTION
Pass verbosity of `tomato-daemon` to `tomato-job` and `tomato-driver`.