### PR TITLE
`yaml` output and `CompletedJob`

### DIFF
--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -103,6 +103,13 @@ def run_tomato():
             type=int,
             default=3000,
         )
+        p.add_argument(
+            "--yaml",
+            "-y",
+            help="Return output as a yaml.",
+            action="store_true",
+            default=False,
+        )
 
     for p in [start, init, reload]:
         p.add_argument(
@@ -140,7 +147,10 @@ def run_tomato():
     context = zmq.Context()
     if "func" in args:
         ret = args.func(**vars(args), context=context, verbosity=verbosity)
-        print(yaml.dump(ret.dict()))
+        if args.yaml:
+            print(yaml.dump(ret.dict()))
+        else:
+            print(f"{'Success' if ret.success else 'Failure'}: {ret.msg}")
 
 
 def run_ketchup():
@@ -253,6 +263,13 @@ def run_ketchup():
             type=int,
             default=3000,
         )
+        p.add_argument(
+            "--yaml",
+            "-y",
+            help="Return output as a yaml.",
+            action="store_true",
+            default=False,
+        )
 
     args, extras = parser.parse_known_args()
     args, extras = verbose.parse_known_args(extras, args)
@@ -264,9 +281,15 @@ def run_ketchup():
         context = zmq.Context()
         status = tomato.status(**vars(args), context=context, with_data=True)
         if not status.success:
-            print(yaml.dump(status.dict()))
+            if args.yaml:
+                print(yaml.dump(status.dict()))
+            else:
+                print(f"Failure: {status.msg}")
         else:
             ret = args.func(
                 **vars(args), verbosity=verbosity, context=context, status=status
             )
-            print(yaml.dump(ret.dict()))
+            if args.yaml:
+                print(yaml.dump(ret.dict()))
+            else:
+                print(f"{'Success' if ret.success else 'Failure'}: {ret.msg}")

--- a/src/tomato/daemon/cmd.py
+++ b/src/tomato/daemon/cmd.py
@@ -240,7 +240,7 @@ def job(msg: dict, daemon: Daemon) -> Reply:
             logger.debug("setting job parameter %s.%s to %s", jobid, k, v)
             setattr(daemon.jobs[jobid], k, v)
         cjob = daemon.jobs[jobid]
-        if cjob.status in {"c", "ce", "cd"}:
+        if cjob.status in {"c"}:
             daemon.jobs[jobid] = CompletedJob(
                 id=cjob.id,
                 status=cjob.status,

--- a/src/tomato/daemon/job.py
+++ b/src/tomato/daemon/job.py
@@ -151,12 +151,14 @@ def check_queued_jobs(daemon: Daemon, req) -> dict[int, list[Pipeline]]:
         )
         if len(matched[job.id]) > 0 and job.status == "q":
             logger.info(
-                f"job {job.id} can queue on pips: {[p.name for p in matched[job.id]]}"
+                "job %d can queue on pips: {%s}",
+                job.id,
+                [p.name for p in matched[job.id]]
             )
             req.send_pyobj(dict(cmd="job", id=job.id, params=dict(status="qw")))
             ret = req.recv_pyobj()
             if not ret.success:
-                logger.error(f"could not set status of job {job.id}")
+                logger.error("could not set status of job %d", job.id)
                 continue
             else:
                 job.status = "qw"
@@ -399,12 +401,12 @@ def tomato_job() -> None:
         logger.error("could not set job status for unknown reason")
         return 1
 
-    logger.info(f"resetting pipeline {pip!r}")
+    logger.info("resetting pipeline '%s'", pip)
     params = dict(jobid=None, ready=ready, name=pip)
     ret = lazy_pirate(pyobj=dict(cmd="pipeline", params=params), **pkwargs)
     logger.debug(f"{ret=}")
     if not ret.success:
-        logger.error(f"could not reset pipeline {pip!r}")
+        logger.error("could not reset pipeline '%s'", pip)
         return 1
     logger.info("exiting tomato-job")
 

--- a/src/tomato/ketchup/__init__.py
+++ b/src/tomato/ketchup/__init__.py
@@ -54,32 +54,22 @@ def submit(
 
     >>> # Submit a job:
     >>> ketchup submit counter_15_0.1.yml
-    data:
-      completed_at: null
-      executed_at: null
-      id: 1
-      jobname: null
-      payload:
-        [...]
-      pid: null
-      status: q
-      submitted_at: '2024-03-03 15:16:49.522866+00:00'
-    msg: job submitted successfully
-    success: true
+    Success: job submitted successfully with jobid 1
 
-    >>> # With a job name:
+    >>> # Submit a job with a job name:
     >>> ketchup submit counter_15_0.1.yml -j jobname_is_this
+    Success: job submitted successfully with jobid 1 and jobname 'jobname_is_this'
+
+    >>> # Submit a job with yaml output:
+    >>> ketchup submit counter_15_0.1.yml -y
     data:
-      completed_at: null
-      executed_at: null
-      id: 2
-      jobname: jobname_is_this
-      payload:
+        completed_at: null
+        executed_at: null
+        id: 1
         [...]
-      pid: null
-      status: q
-      submitted_at: '2024-03-03 15:19:09.856354+00:00'
-    msg: job submitted successfully
+        status: q
+        submitted_at: '2024-11-17 19:39:16.972593+00:00'
+    msg: job submitted successfully with jobid 1
     success: true
 
     """
@@ -123,7 +113,10 @@ def submit(
     req.send_pyobj(dict(cmd="job", id=None, params=params))
     ret = req.recv_pyobj()
     if ret.success:
-        return Reply(success=True, msg="job submitted successfully", data=ret.data)
+        msg = f"job submitted successfully with jobid {ret.data.id}"
+        if ret.data.jobname is not None:
+            msg += f" and jobname {ret.data.jobname!r}"
+        return Reply(success=True, msg=msg,data=ret.data)
     else:
         return Reply(success=False, msg="unknown error", data=ret.data)
 
@@ -153,52 +146,28 @@ def status(
 
     >>> # Get status of a given job
     >>> ketchup status 1
-    data:
-      1:
-        completed_at: null
-        executed_at: null
-        id: 1
-        jobname: null
-        payload:
-          [...]
-        pid: null
-        status: qw
-        submitted_at: '2024-03-03 15:16:49.522866+00:00'
-    msg: found 1 queued jobs
-    success: true
+    Success: found 1 job with status ['qw']
 
     >>> # Get status of multiple jobs
     >>> ketchup status 1 2
-    data:
-      1:
-        completed_at: null
-        executed_at: null
-        id: 1
-        jobname: counter
-        payload:
-          [...]
-        pid: null
-        status: qw
-        submitted_at: '2024-03-03 15:16:49.522866+00:00'
-    data:
-      1:
-        completed_at: '2024-03-03 15:27:44.660493+00:00'
-        executed_at: '2024-03-03 15:27:28.593896+00:00'
-        id: 1
-        jobname: null
-        payload:
-          [...]
-        pid: 514771
-        status: c
-        submitted_at: '2024-03-03 15:23:40.987074+00:00'
-    msg: found 2 queued jobs
-    success: true
+    Success: found 2 jobs with statuses ['qw', 'qw']
 
     >>> # Get status of non-existent job
     >>> ketchup status 3
-    data: {}
-    msg: found 0 queued jobs
+    Failure: found no jobs with jobids [3]
+
+    >>> # Get a status of a job with yaml output
+    >>> ketchup status 1 -y
+    data:
+      - completed_at: null
+        executed_at: null
+        id: 1
+        [...]
+        status: qw
+        submitted_at: '2024-11-17 17:53:46.133355+00:00'
+    msg: found 1 job with status ['qw']
     success: true
+
 
     """
     jobs = status.data.jobs
@@ -207,8 +176,18 @@ def status(
     elif len(jobids) == 0:
         return Reply(success=True, msg=f"found {len(jobs)} queued jobs", data=jobs)
     else:
-        rets = {job.id: job for job in jobs.values() if job.id in jobids}
-        return Reply(success=True, msg=f"found {len(rets)} queued jobs", data=rets)
+        rets = [job for job in jobs.values() if job.id in jobids]
+        if len(rets) == 0:
+            return Reply(success=False, msg=f"found no jobs with jobids {jobids!r}")
+        elif len(rets) == 1:
+            msg = f"found {len(rets)} job with status {[job.status for job in rets]}"
+        else:
+            msg = f"found {len(rets)} jobs with statuses {[job.status for job in rets]}"
+        return Reply(
+            success=True,
+            msg=msg,
+            data=rets
+        )
 
 
 def cancel(
@@ -232,36 +211,20 @@ def cancel(
     Examples
     --------
 
-    >>> # Cancel a queued job:
-    >>> ketchup cancel 2
+    >>> # Cancel a job:
+    >>> ketchup cancel 1
+    Success: job [1] cancelled successfully
+
+    >>> # Cancel a job with yaml output:
+    >>> ketchup cancel 2 -y
     data:
-      2:
-        completed_at: null
+      - completed_at: null
         executed_at: null
         id: 2
-        jobname: null
-        payload:
-          [...]
-        pid: null
+        [...]
         status: cd
         submitted_at: '2024-03-03 15:23:50.702504+00:00'
-    msg: cancelled jobs successfully
-    success: true
-
-    >>> # Cancel a running job:
-    >>> ketchup cancel 3
-    data:
-      3:
-        completed_at: null
-        executed_at: '2024-03-03 15:37:45.635442+00:00'
-        id: 3
-        jobname: null
-        payload:
-          [...]
-        pid: 515678
-        status: rd
-        submitted_at: '2024-03-03 15:37:44.858713+00:00'
-    msg: cancelled jobs successfully
+    msg: job [2] cancelled successfully
     success: true
 
     """
@@ -272,7 +235,7 @@ def cancel(
 
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{port}")
-    data = {}
+    data = []
     for jobid in jobids:
         if jobs[jobid].status in {"q", "qw"}:
             params = dict(status="cd")
@@ -283,10 +246,14 @@ def cancel(
         req.send_pyobj(dict(cmd="job", id=jobid, params=params))
         ret = req.recv_pyobj()
         if ret.success:
-            data[jobid] = ret.data
+            data.append(ret.data)
         else:
             return Reply(success=False, msg="unknown error", data=ret.data)
-    return Reply(success=True, msg="cancelled jobs successfully", data=data)
+    if len(data) == 1:
+        msg = f"job {[j.id for j in data]} cancelled successfully"
+    else:
+        msg = f"jobs {[j.id for j in data]} cancelled successfully"
+    return Reply(success=True, msg=msg, data=data)
 
 
 def snapshot(
@@ -306,10 +273,7 @@ def snapshot(
 
     >>> # Create a snapshot in current working directory:
     >>> ketchup snapshot 3
-    data: null
-    msg: snapshot for job(s) [3] created successfully
-    success: true
-
+    Success: snapshot for job [3] created successfully
 
     """
     jobs = status.data.jobs
@@ -321,7 +285,11 @@ def snapshot(
 
     for jobid in jobids:
         merge_netcdfs(Path(jobs[jobid].jobpath), Path(f"snapshot.{jobid}.nc"))
-    return Reply(success=True, msg=f"snapshot for job(s) {jobids} created successfully")
+    if len(jobids) > 1:
+        msg = f"snapshot for jobs {jobids} created successfully"
+    else:
+        msg = f"snapshot for job {jobids} created successfully"
+    return Reply(success=True, msg=msg)
 
 
 def search(

--- a/src/tomato/models.py
+++ b/src/tomato/models.py
@@ -6,7 +6,7 @@
 """
 
 from pydantic import BaseModel, Field, field_validator
-from typing import Optional, Any, Mapping, Sequence, Literal
+from typing import Optional, Any, Mapping, Sequence, Literal, Union
 import logging
 
 
@@ -82,6 +82,14 @@ class Job(BaseModel):
     snappath: Optional[str] = None
 
 
+class CompletedJob(BaseModel):
+    id: int
+    status: Literal["c", "cd", "ce"]
+    completed_at: str
+    jobpath: str
+    respath: str
+
+
 class Daemon(BaseModel, arbitrary_types_allowed=True):
     status: Literal["bootstrap", "running", "stop"]
     port: int
@@ -93,7 +101,7 @@ class Daemon(BaseModel, arbitrary_types_allowed=True):
     devs: Mapping[str, Device] = Field(default_factory=dict)
     drvs: Mapping[str, Driver] = Field(default_factory=dict)
     cmps: Mapping[str, Component] = Field(default_factory=dict)
-    jobs: Mapping[int, Job] = Field(default_factory=dict)
+    jobs: Mapping[int, Union[Job, CompletedJob]] = Field(default_factory=dict)
     nextjob: int = 1
 
 

--- a/src/tomato/models.py
+++ b/src/tomato/models.py
@@ -7,7 +7,6 @@
 
 from pydantic import BaseModel, Field, field_validator
 from typing import Optional, Any, Mapping, Sequence, Literal
-from pathlib import Path
 import logging
 
 
@@ -87,8 +86,8 @@ class Daemon(BaseModel, arbitrary_types_allowed=True):
     status: Literal["bootstrap", "running", "stop"]
     port: int
     verbosity: int
-    logdir: Path
-    appdir: Path
+    logdir: str
+    appdir: str
     settings: dict
     pips: Mapping[str, Pipeline] = Field(default_factory=dict)
     devs: Mapping[str, Device] = Field(default_factory=dict)

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -175,8 +175,8 @@ def start(
     port: int,
     timeout: int,
     context: zmq.Context,
-    appdir: Path,
-    logdir: Path,
+    appdir: str,
+    logdir: str,
     verbosity: int,
     **_: dict,
 ) -> Reply:
@@ -202,7 +202,7 @@ def start(
             msg=f"required port {port} is already in use, choose a different one",
         )
 
-    if not (appdir / "settings.toml").exists():
+    if not (Path(appdir) / "settings.toml").exists():
         return Reply(
             success=False,
             msg=f"settings file not found in {appdir}, run 'tomato init' to create one",
@@ -262,8 +262,8 @@ def stop(
 
 def init(
     *,
-    appdir: Path,
-    datadir: Path,
+    appdir: str,
+    datadir: str,
     **_: dict,
 ) -> Reply:
     """
@@ -271,6 +271,8 @@ def init(
 
     Will overwrite any existing settings.toml file.
     """
+    appdir = Path(appdir)
+    datadir = Path(datadir)
     defaults = textwrap.dedent(
         f"""\
         # Default settings for tomato-{VERSION}
@@ -303,7 +305,7 @@ def reload(
     port: int,
     timeout: int,
     context: zmq.Context,
-    appdir: Path,
+    appdir: str,
     **_: dict,
 ) -> Reply:
     """
@@ -312,7 +314,7 @@ def reload(
     kwargs = dict(port=port, timeout=timeout, context=context)
     logger.debug("Loading settings.toml file from %s.", appdir)
     try:
-        settings = toml.load(appdir / "settings.toml")
+        settings = toml.load(Path(appdir) / "settings.toml")
     except FileNotFoundError:
         return Reply(
             success=False,

--- a/tests/test_02_ketchup.py
+++ b/tests/test_02_ketchup.py
@@ -71,7 +71,7 @@ def test_ketchup_status_one_queued(datadir, start_tomato_daemon, stop_tomato_dae
     assert ret.success
     assert "found 1" in ret.msg
     assert len(ret.data) == 1
-    assert 2 in ret.data.keys()
+    assert ret.data[0].id == 2
 
 
 def test_ketchup_status_two_queued(datadir, start_tomato_daemon, stop_tomato_daemon):
@@ -83,8 +83,8 @@ def test_ketchup_status_two_queued(datadir, start_tomato_daemon, stop_tomato_dae
     assert ret.success
     assert "found 2" in ret.msg
     assert len(ret.data) == 2
-    assert 1 in ret.data.keys()
-    assert 2 in ret.data.keys()
+    assert ret.data[0].id == 1
+    assert ret.data[1].id == 2
 
 
 @pytest.mark.parametrize(
@@ -105,7 +105,7 @@ def test_ketchup_status_running(pl, datadir, start_tomato_daemon, stop_tomato_da
     assert ret.success
     assert "found 1" in ret.msg
     assert len(ret.data) == 1
-    assert ret.data[1].status == "r"
+    assert ret.data[0].status == "r"
 
 
 @pytest.mark.parametrize(
@@ -124,7 +124,7 @@ def test_ketchup_status_complete(pl, datadir, start_tomato_daemon, stop_tomato_d
     ret = ketchup.status(**kwargs, status=status, verbosity=0, jobids=[1])
     print(f"{ret=}")
     assert ret.success
-    assert ret.data[1].status == "c"
+    assert ret.data[0].status == "c"
     assert os.path.exists("results.1.nc")
 
 
@@ -146,7 +146,7 @@ def test_ketchup_cancel_running(pl, datadir, start_tomato_daemon, stop_tomato_da
     ret = ketchup.cancel(**kwargs, status=status, verbosity=0, jobids=[1])
     print(f"{ret=}")
     assert ret.success
-    assert ret.data[1].status == "rd"
+    assert ret.data[0].status == "rd"
 
     assert wait_until_ketchup_status(jobid=1, status="cd", port=PORT, timeout=5000)
     status = tomato.status(**kwargs, with_data=True)
@@ -155,7 +155,7 @@ def test_ketchup_cancel_running(pl, datadir, start_tomato_daemon, stop_tomato_da
     print(f"{os.listdir()=}")
     print(f"{os.listdir('Jobs')=}")
     print(f"{os.listdir(os.path.join('Jobs', '1'))=}")
-    assert ret.data[1].status == "cd"
+    assert ret.data[0].status == "cd"
     assert os.path.exists("results.1.nc")
 
 
@@ -175,7 +175,7 @@ def test_ketchup_cancel_queued(pl, datadir, start_tomato_daemon, stop_tomato_dae
     ret = ketchup.cancel(**kwargs, status=status, verbosity=0, jobids=[1])
     print(f"{ret=}")
     assert ret.success
-    assert ret.data[1].status == "cd"
+    assert ret.data[0].status == "cd"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_99_example_counter.py
+++ b/tests/test_99_example_counter.py
@@ -26,10 +26,10 @@ def test_counter_npoints(
 ):
     os.chdir(datadir)
     utils.run_casenames([casename], [None], ["pip-counter"])
-    status = utils.job_status(1)["data"][1]["status"]
+    status = utils.job_status(1)
     while status in {"q", "qw", "r"}:
         time.sleep(1)
-        status = utils.job_status(1)["data"][1]["status"]
+        status = utils.job_status(1)
     assert status == "c"
     files = os.listdir(os.path.join(".", "Jobs", "1"))
     assert "jobdata.json" in files
@@ -52,16 +52,14 @@ def test_counter_cancel(casename, datadir, start_tomato_daemon, stop_tomato_daem
     os.chdir(datadir)
     cancel = True
     utils.run_casenames([casename], [None], ["pip-counter"])
-    ret = utils.job_status(1)
-    status = ret["data"][1]["status"]
+    status = utils.job_status(1)
     while status in {"q", "qw", "r", "rd"}:
         time.sleep(2)
         if cancel and status == "r":
             subprocess.run(["ketchup", "cancel", "-p", "12345", "1"])
             cancel = False
             time.sleep(2)
-        ret = utils.job_status(1)
-        status = ret["data"][1]["status"]
+        status = utils.job_status(1)
     assert status == "cd"
 
 
@@ -78,13 +76,13 @@ def test_counter_snapshot(
     os.chdir(datadir)
     utils.run_casenames([casename], [None], ["pip-counter"])
     time.sleep(5)
-    status = utils.job_status(1)["data"][1]["status"]
+    status = utils.job_status(1)
     while status in {"q", "qw", "r"}:
         time.sleep(1)
         if external and status == "r":
             subprocess.run(["ketchup", "snapshot", "-p", "12345", "1"])
             external = False
-        status = utils.job_status(1)["data"][1]["status"]
+        status = utils.job_status(1)
     assert status == "c"
     assert os.path.exists("snapshot.1.nc")
 
@@ -110,9 +108,7 @@ def test_counter_multidev(casename, npoints, datadir, stop_tomato_daemon):
     utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=10000)
     utils.wait_until_ketchup_status(jobid=1, status="c", port=PORT, timeout=10000)
 
-    ret = utils.job_status(1)
-    print(f"{ret=}")
-    status = utils.job_status(1)["data"][1]["status"]
+    status = utils.job_status(1)
     assert status == "c"
     files = os.listdir(os.path.join(".", "Jobs", "1"))
     assert "jobdata.json" in files

--- a/tests/test_99_psutil.py
+++ b/tests/test_99_psutil.py
@@ -31,9 +31,7 @@ def test_psutil_multidev(casename, npoints, datadir, stop_tomato_daemon):
     utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=2000)
     utils.wait_until_ketchup_status(jobid=1, status="c", port=PORT, timeout=2000)
 
-    ret = utils.job_status(1)
-    print(f"{ret=}")
-    status = utils.job_status(1)["data"][1]["status"]
+    status = utils.job_status(1)
     assert status == "c"
     files = os.listdir(os.path.join(".", "Jobs", "1"))
     assert "jobdata.json" in files

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 import subprocess
 import time
-import yaml
 import logging
 import os
 import psutil
@@ -27,8 +26,8 @@ def job_status(jobid):
         capture_output=True,
         text=True,
     )
-    yml = yaml.safe_load(ret.stdout)
-    return yml
+    status = ret.stdout.split("'")[1]
+    return status
 
 
 def wait_until_tomato_running(port: int, timeout: int):
@@ -39,8 +38,7 @@ def wait_until_tomato_running(port: int, timeout: int):
             capture_output=True,
             text=True,
         )
-        data = yaml.safe_load(ret.stdout)
-        if data["success"]:
+        if "Success" in ret.stdout:
             return True
         time.sleep(0.5)
     return False
@@ -54,8 +52,7 @@ def wait_until_tomato_stopped(port: int, timeout: int):
             capture_output=True,
             text=True,
         )
-        data = yaml.safe_load(ret.stdout)
-        if not data["success"]:
+        if "Failure" in ret.stdout:
             return True
         time.sleep(0.5)
     return False
@@ -69,8 +66,7 @@ def wait_until_ketchup_status(jobid: int, status: str, port: int, timeout: int):
             capture_output=True,
             text=True,
         )
-        data = yaml.safe_load(ret.stdout)["data"]
-        if data[jobid]["status"] == status:
+        if f"[{status!r}]" in ret.stdout:
             return True
         time.sleep(0.5)
     return False


### PR DESCRIPTION
- Replaces completed jobs by smaller `CompletedJob` datastructures to reduce overhead.
- Closes #100 by adding `--yaml` option to `ketchup` and `tomato`.