### PR TITLE
Store `Job` and tomato version in NetCDF files.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -178,9 +178,16 @@ Final job data
 **************
 By default, all data in the *job* folder is processed to create a NetCDF file. The NetCDF files can be read using :func:`xaray.open_datatree`, returning a :class:`xarray.DataTree`.
 
-In the root node of the :class:`~xarray.DataTree`, a copy of the full *payload* is included, serialised as a json :class:`str`. Additionally, execution-specific metadata, such as the *pipeline* ``name``, and *job* submission/execution/completion time are stored on the root node, too.
+In the root node of the :class:`~xarray.DataTree`, the :obj:`attrs` dictionary contains all **tomato**-relevant metadata. This currently includes:
 
-The child nodes of the :class:`~xarray.DataTree` contain the actual data from each *pipeline* *component*, unit-annotated using the CF Metadata Conventions. The node names correspond to the ``role`` that *component* fullfils in a *pipeline*.
+- ``tomato_version`` which is the version of **tomato** used to create the NetCDF file,
+- ``tomato_Job`` which is the *job* object serialised as a json :class:`str`, containing the full *payload*, sample information, as well as *job* submission/execution/completion time.
+
+The child nodes of the :class:`~xarray.DataTree` contain the actual data from each *pipeline* *component*, unit-annotated using the CF Metadata Conventions. The node names correspond to the ``role`` that *component* fullfils in a *pipeline*. The :obj:`attrs` dictionary of each node contains a ``tomato_Component`` entry, which is the *component* object serialised as a json :class:`str`, containing information about the *device* address and channel defining the *component* as well as its capabilities.
+
+.. note::
+
+    The ``tomato_Job`` and ``tomato_Component`` entries can be converted back to the source objects using :func:`tomato.models.Job.model_validate_json` and :func:`tomato.models.Component.model_validate_json`, respectively.
 
 .. note::
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -174,8 +174,8 @@ Each *job* stores its data and logs in its own *job* folder, which is a subfolde
     Note that a *pipeline* dashboard functionality is planned for a future version of ``tomato``.
 
 
-Final job data
-**************
+Final job data and metadata
+***************************
 By default, all data in the *job* folder is processed to create a NetCDF file. The NetCDF files can be read using :func:`xaray.open_datatree`, returning a :class:`xarray.DataTree`.
 
 In the root node of the :class:`~xarray.DataTree`, the :obj:`attrs` dictionary contains all **tomato**-relevant metadata. This currently includes:
@@ -183,7 +183,10 @@ In the root node of the :class:`~xarray.DataTree`, the :obj:`attrs` dictionary c
 - ``tomato_version`` which is the version of **tomato** used to create the NetCDF file,
 - ``tomato_Job`` which is the *job* object serialised as a json :class:`str`, containing the full *payload*, sample information, as well as *job* submission/execution/completion time.
 
-The child nodes of the :class:`~xarray.DataTree` contain the actual data from each *pipeline* *component*, unit-annotated using the CF Metadata Conventions. The node names correspond to the ``role`` that *component* fullfils in a *pipeline*. The :obj:`attrs` dictionary of each node contains a ``tomato_Component`` entry, which is the *component* object serialised as a json :class:`str`, containing information about the *device* address and channel defining the *component* as well as its capabilities.
+The child nodes of the :class:`~xarray.DataTree` contain:
+
+- the actual data from each *pipeline* *component*, unit-annotated using the CF Metadata Conventions. The node names correspond to the ``role`` that *component* fullfils in a *pipeline*.
+- a ``tomato_Component`` entry in the :obj:`attrs` object, which is the *component* object serialised as a json :class:`str`, containing information about the *device* address and channel that define the *component*, the *driver* and *device* names, as well as the *component* capabilities.
 
 .. note::
 

--- a/src/tomato/daemon/cmd.py
+++ b/src/tomato/daemon/cmd.py
@@ -232,11 +232,13 @@ def job(msg: dict, daemon: Daemon) -> Reply:
         daemon.jobs[jobid] = Job(id=jobid, **msg.get("params", {}))
         logger.info("received job %d", jobid)
         daemon.nextjob += 1
+        ret = daemon.jobs[jobid]
     else:
         for k, v in msg.get("params", {}).items():
             logger.debug("setting job parameter %s.%s to %s", jobid, k, v)
             setattr(daemon.jobs[jobid], k, v)
         cjob = daemon.jobs[jobid]
+        ret = cjob
         if cjob.status in {"c"}:
             daemon.jobs[jobid] = CompletedJob(
                 id=cjob.id,
@@ -246,7 +248,7 @@ def job(msg: dict, daemon: Daemon) -> Reply:
                 jobpath=cjob.jobpath,
                 respath=cjob.respath,
             )
-    return Reply(success=True, msg="job updated", data=daemon.jobs[jobid])
+    return Reply(success=True, msg="job updated", data=ret)
 
 
 def driver(msg: dict, daemon: Daemon) -> Reply:

--- a/src/tomato/daemon/job.py
+++ b/src/tomato/daemon/job.py
@@ -470,7 +470,9 @@ def job_thread(
                 ret = req.recv_pyobj()
                 if ret.success:
                     logger.debug("pickling received data")
-                    data_to_pickle(ret.data, datapath, role=component.role)
+                    ds = ret.data
+                    ds.attrs["tomato_Component"] = component.model_dump_json()
+                    data_to_pickle(ds, datapath, role=component.role)
                 t0 += device.pollrate
 
             logger.debug("polling component '%s' for task completion", component.role)

--- a/src/tomato/ketchup/__init__.py
+++ b/src/tomato/ketchup/__init__.py
@@ -25,7 +25,7 @@ from packaging.version import Version
 from dgbowl_schemas.tomato import to_payload
 
 from tomato.daemon.io import merge_netcdfs
-from tomato.models import Reply, Daemon
+from tomato.models import Reply, Daemon, Job
 
 log = logging.getLogger(__name__)
 
@@ -288,7 +288,7 @@ def snapshot(
     Success: snapshot for job [3] created successfully
 
     """
-    jobs = status.data.jobs
+    jobs: list[Job] = status.data.jobs
     for jobid in jobids:
         if jobid not in jobs:
             return Reply(success=False, msg=f"job {jobid} does not exist")
@@ -296,7 +296,8 @@ def snapshot(
             return Reply(success=False, msg=f"job {jobid} is still queued")
 
     for jobid in jobids:
-        merge_netcdfs(Path(jobs[jobid].jobpath), Path(f"snapshot.{jobid}.nc"))
+        jobs[jobid].snappath = Path(f"snapshot.{jobid}.nc")
+        merge_netcdfs(jobs[jobid], snapshot=True)
     if len(jobids) > 1:
         msg = f"snapshot for jobs {jobids} created successfully"
     else:

--- a/tests/test_99_example_counter.py
+++ b/tests/test_99_example_counter.py
@@ -21,7 +21,7 @@ PORT = 12345
         ("counter_multistep", 15, "results.1"),
     ],
 )
-def test_counter_npoints(
+def test_counter_npoints_metadata(
     casename, npoints, prefix, datadir, start_tomato_daemon, stop_tomato_daemon
 ):
     os.chdir(datadir)
@@ -40,6 +40,8 @@ def test_counter_npoints(
         ds = dt["counter"]
         print(f"{ds=}")
         assert ds["uts"].size == npoints
+        assert "tomato_version" in dt.attrs
+        assert "tomato_Job" in dt.attrs
 
 
 @pytest.mark.parametrize(
@@ -70,7 +72,7 @@ def test_counter_cancel(casename, datadir, start_tomato_daemon, stop_tomato_daem
         ("counter_snapshot", False),
     ],
 )
-def test_counter_snapshot(
+def test_counter_snapshot_metadata(
     casename, external, datadir, start_tomato_daemon, stop_tomato_daemon
 ):
     os.chdir(datadir)
@@ -85,6 +87,9 @@ def test_counter_snapshot(
         status = utils.job_status(1)
     assert status == "c"
     assert os.path.exists("snapshot.1.nc")
+    dt = xr.open_datatree("snapshot.1.nc")
+    assert "tomato_version" in dt.attrs
+    assert "tomato_Job" in dt.attrs
 
 
 @pytest.mark.parametrize(

--- a/tests/test_99_example_counter.py
+++ b/tests/test_99_example_counter.py
@@ -46,7 +46,6 @@ def test_counter_npoints_metadata(
         assert "tomato_Component" in ds.attrs
 
 
-
 @pytest.mark.parametrize(
     "casename",
     [

--- a/tests/test_99_example_counter.py
+++ b/tests/test_99_example_counter.py
@@ -37,11 +37,14 @@ def test_counter_npoints_metadata(
     if prefix is not None:
         assert os.path.exists(f"{prefix}.nc")
         dt = xr.open_datatree(f"{prefix}.nc")
+        assert "tomato_version" in dt.attrs
+        assert "tomato_Job" in dt.attrs
+
         ds = dt["counter"]
         print(f"{ds=}")
         assert ds["uts"].size == npoints
-        assert "tomato_version" in dt.attrs
-        assert "tomato_Job" in dt.attrs
+        assert "tomato_Component" in ds.attrs
+
 
 
 @pytest.mark.parametrize(
@@ -90,6 +93,8 @@ def test_counter_snapshot_metadata(
     dt = xr.open_datatree("snapshot.1.nc")
     assert "tomato_version" in dt.attrs
     assert "tomato_Job" in dt.attrs
+    for group in dt:
+        assert "tomato_Component" in dt[group].attrs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #106 by introducing `tomato_version` and `tomato_Job` metadata on the root node of the `DataTree`.

Closes #85 by including per-component metadata in `tomato_Component` on each child node of the `DataTree`.