### PR TITLE
`tomato status`: Rework `tomato status`

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -75,6 +75,13 @@ The :mod:`tomato.tomato` executable is used to configure, start, and manage the 
 
     #. **To manage individual pipelines** of a running **tomato** daemon, the following commands are available:
 
+        - For checking the status of all configured *pipelines*:
+
+            .. code-block:: bash
+
+                >>> tomato status --pipeline
+
+
         - For loading a sample into a *pipeline*:
 
             .. code-block:: bash

--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -1,5 +1,21 @@
 Version history
 ===============
+**tomato**-v1.1
+---------------
+
+.. sectionauthor::
+     Peter Kraus
+
+Developed at the ConCat lab at TU Berlin.
+
+Changes from ``tomato-1.0`` include:
+
+- ``logdir`` can now be set in *settings file*, with the default value configurable using ``tomato init``.
+- ``tomato status`` now supports further arguments: ``--pipelines``, ``--drivers``, ``--devices``, and ``--components`` can be used to query status of subsets of the running **tomato**
+
+.. codeauthor::
+    Peter Kraus
+    
 
 **tomato**-v1.0
 ---------------

--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -37,6 +37,28 @@ def run_tomato():
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
     status = subparsers.add_parser("status")
+    stgrp = status.add_mutually_exclusive_group()
+    grpargs = dict(dest="stgrp", action="store_const")
+    stgrp.add_argument(
+        "--tomato",
+        "--tom",
+        **grpargs,
+        const="tom",
+        help="Show tomato status.",
+        default="tom",
+    )
+    stgrp.add_argument(
+        "--pipelines", "--pip", **grpargs, const="pip", help="Show tomato pipelines."
+    )
+    stgrp.add_argument(
+        "--drivers", "--drv", **grpargs, const="drv", help="Show tomato drivers."
+    )
+    stgrp.add_argument(
+        "--devices", "--dev", **grpargs, const="dev", help="Show tomato devices."
+    )
+    stgrp.add_argument(
+        "--components", "--cmp", **grpargs, const="cmp", help="Show tomato components."
+    )
     status.set_defaults(func=tomato.status)
 
     start = subparsers.add_parser("start")

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -266,6 +266,26 @@ def status(
     msg: tomato running on port 1234
     success: true
 
+    >>> # Status of all configured pipelines
+    >>> tomato status --pipeline
+    Success: tomato running on port 1234 with the following pipelines:
+         name:pip-counter       ready:False     sampleid:counter_1_0.1  jobid:None
+    
+    >>> # Status of all configured drivers
+    >>> tomato status --drivers
+    Success: tomato running on port 1234 with the following drivers:
+         name:example_counter   port:34747      pid:192318
+    
+    >>> # Status of all configured devices
+    >>> tomato status --devices
+    Success: tomato running on port 1234 with the following devices:
+         name:dev-counter       driver:example_counter  address:example-addr    channels:['1']
+
+    >>> # Status of all configured components:
+    >>> tomato status --components
+    Success: tomato running on port 1234 with the following components:
+         name:example_counter:(example-addr,1)  driver:example_counter  device:dev-counter      role:counter
+
     """
     logger.debug("checking status of tomato on port %d", port)
     req = context.socket(zmq.REQ)

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -270,12 +270,12 @@ def status(
     >>> tomato status --pipeline
     Success: tomato running on port 1234 with the following pipelines:
          name:pip-counter       ready:False     sampleid:counter_1_0.1  jobid:None
-    
+
     >>> # Status of all configured drivers
     >>> tomato status --drivers
     Success: tomato running on port 1234 with the following drivers:
          name:example_counter   port:34747      pid:192318
-    
+
     >>> # Status of all configured devices
     >>> tomato status --devices
     Success: tomato running on port 1234 with the following devices:


### PR DESCRIPTION
This PR reworks how `tomato status` works while maintaining backwards compatibility.

Additional (optional) argument `stgrp` is added to `tomato.status()`, which defaults to `"tom"`, which means the overall tomato status is returned (or the `Daemon` object as a whole).

Further options are `--pipelines/--pip`, `--devices/--dev`, `--drivers/--drv`, and `--components/--cmp`, which print a table or return the appropriate sub-section of the `Daemon` object.  