### PR TITLE
Keep track of `Jobs` using sqlite

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -56,6 +56,10 @@ These two executables then internally spawn other processes, including the state
           mp([main loop]) --> tp>task process]
       end
 
+      cmd ==> db[(job db\nsqlite)]
+      jm -.-> db
+      mp -.-> db
+
       t>tomato] -.-> cmd
       k>ketchup] -.-> cmd
 
@@ -152,6 +156,7 @@ The *settings file* contains the basic information required to start the ``tomat
 
     [jobs]
     storage = '/home/kraus/.local/share/tomato/1.0a1/Jobs'
+    dbpath = '/home/kraus/.local/share/tomato/1.0a1/Jobs/dbpath.sqlite'
 
     [devices]
     config = '/home/kraus/.config/tomato/1.0a1/devices.yml'
@@ -172,7 +177,8 @@ Finally, another path, *logdir*, is used to specify where logs for **tomato** ar
 
 In the default *settings file* shown above, the following entries are specified:
 
-- ``jobs.storage`` which is the directory where the data of **tomato** jobs will be stored,
+- ``jobs.storage`` which is the directory where the data of **tomato** *jobs* will be stored,
+- ``jobs.dbpath`` which is the location of the ``sqlite3`` database used to track *jobs*, 
 - ``devices.config`` which points to a ``yaml``-formatted :ref:`devices file <devfile>`, defining the hardware configuration of the devices managed by **tomato**.
 
 Additional, *driver*-specific settings may be provided in the ``[drivers]`` section, following the example of the ``drivers.example_counter.testpar`` entry. These *driver*-specific settings are passed to each *driver* when its process is launched and the :class:`DriverInterface` is initialised, and can therefore contain paths to various libraries or other files necessary for the *driver* to function.

--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -10,6 +10,7 @@ Developed at the ConCat lab at TU Berlin.
 
 Changes from ``tomato-1.0`` include:
 
+- *jobs* are now tracked in a queue stored in a ``sqlite3`` database instead of on the ``tomato.daemon``.
 - ``logdir`` can now be set in *settings file*, with the default value configurable using ``tomato init``.
 - ``tomato status`` now supports further arguments: ``--pipelines``, ``--drivers``, ``--devices``, and ``--components`` can be used to query status of subsets of the running **tomato**
 

--- a/src/tomato/daemon/__init__.py
+++ b/src/tomato/daemon/__init__.py
@@ -88,6 +88,8 @@ def tomato_daemon():
                 ret = Reply(success=False, msg="received msg without cmd", data=msg)
             elif hasattr(cmd, msg["cmd"]):
                 ret = getattr(cmd, msg["cmd"])(msg, daemon)
+            else:
+                logger.error(f"received msg with an invalid cmd: {msg=}")
             logger.debug(f"reply with {ret=}")
             rep.send_pyobj(ret)
         if daemon.status == "stop":

--- a/src/tomato/daemon/__init__.py
+++ b/src/tomato/daemon/__init__.py
@@ -19,6 +19,7 @@ import tomato.daemon.cmd as cmd
 import tomato.daemon.job
 import tomato.daemon.driver
 import tomato.daemon.io as io
+import tomato.daemon.jobdb as jobdb
 
 logger = logging.getLogger(__name__)
 

--- a/src/tomato/daemon/__init__.py
+++ b/src/tomato/daemon/__init__.py
@@ -19,7 +19,6 @@ import tomato.daemon.cmd as cmd
 import tomato.daemon.job
 import tomato.daemon.driver
 import tomato.daemon.io as io
-import tomato.daemon.jobdb as jobdb
 
 logger = logging.getLogger(__name__)
 

--- a/src/tomato/daemon/cmd.py
+++ b/src/tomato/daemon/cmd.py
@@ -225,7 +225,6 @@ def pipeline(msg: dict, daemon: Daemon) -> Reply:
 
 def set_job(msg: dict, daemon: Daemon) -> Reply:
     logger = logging.getLogger(f"{__name__}.set_job")
-    logger.debug("%s", msg)
     dbpath = daemon.settings["jobs"]["dbpath"]
     if msg["id"] is None:
         job = Job(**msg.get("params", {}))
@@ -238,7 +237,6 @@ def set_job(msg: dict, daemon: Daemon) -> Reply:
 
 
 def get_jobs(msg: dict, daemon: Daemon) -> Reply:
-    logger = logging.getLogger(f"{__name__}.get_jobs")
     dbpath = daemon.settings["jobs"]["dbpath"]
     jobs = jobdb.get_jobs_where(msg["where"], dbpath)
     return Reply(success=True, msg=f"found {len(jobs)} jobs", data=jobs)

--- a/src/tomato/daemon/cmd.py
+++ b/src/tomato/daemon/cmd.py
@@ -226,7 +226,7 @@ def pipeline(msg: dict, daemon: Daemon) -> Reply:
 def set_job(msg: dict, daemon: Daemon) -> Reply:
     logger = logging.getLogger(f"{__name__}.set_job")
     logger.debug("%s", msg)
-    dbpath = daemon.settings['jobs']['dbpath']
+    dbpath = daemon.settings["jobs"]["dbpath"]
     if msg["id"] is None:
         job = Job(**msg.get("params", {}))
         job.id = jobdb.insert_job(job, dbpath)
@@ -239,7 +239,7 @@ def set_job(msg: dict, daemon: Daemon) -> Reply:
 
 def get_jobs(msg: dict, daemon: Daemon) -> Reply:
     logger = logging.getLogger(f"{__name__}.get_jobs")
-    dbpath = daemon.settings['jobs']['dbpath']
+    dbpath = daemon.settings["jobs"]["dbpath"]
     jobs = jobdb.get_jobs_where(msg["where"], dbpath)
     return Reply(success=True, msg=f"found {len(jobs)} jobs", data=jobs)
 

--- a/src/tomato/daemon/io.py
+++ b/src/tomato/daemon/io.py
@@ -34,12 +34,10 @@ def load(daemon: Daemon):
         return
     with infile.open("rb") as inp:
         loaded = pickle.load(inp)
-    daemon.jobs = loaded.jobs
     daemon.pips = loaded.pips
     daemon.devs = loaded.devs
     daemon.drvs = loaded.drvs
     daemon.cmps = loaded.cmps
-    daemon.nextjob = loaded.nextjob
     daemon.status = "running"
 
 

--- a/src/tomato/daemon/job.py
+++ b/src/tomato/daemon/job.py
@@ -363,14 +363,15 @@ def tomato_job() -> None:
     job_main_loop(context, args.port, job, pip, logpath)
     logger.info("==============================")
 
-    logger.info("writing final data to a NetCDF file")
-    merge_netcdfs(job)
-
     logger.info("job finished successfully, setting job status to 'c'")
     job.completed_at = str(datetime.now(timezone.utc))
     job.status = "c"
     params = dict(status=job.status, completed_at=job.completed_at)
     job = jobdb.update_job_id(job.id, params, args.dbpath)
+
+    logger.info("writing final data to a NetCDF file")
+    merge_netcdfs(job)
+
     logger.debug(f"{job=}")
     logger.info("exiting tomato-job")
 

--- a/src/tomato/daemon/job.py
+++ b/src/tomato/daemon/job.py
@@ -27,7 +27,7 @@ import zmq
 import psutil
 
 from tomato.daemon.io import merge_netcdfs, data_to_pickle
-from tomato.models import Pipeline, Daemon, Component, Device, Driver, Job, CompletedJob
+from tomato.models import Pipeline, Daemon, Component, Device, Driver, Job
 from dgbowl_schemas.tomato import to_payload
 from dgbowl_schemas.tomato.payload import Task
 
@@ -100,7 +100,7 @@ def manage_running_pips(daemon: Daemon, req):
     logger.debug(f"{running=}")
     for pip in running:
         job = daemon.jobs[pip.jobid]
-        if isinstance(job, CompletedJob):
+        if job.status in {"rd", "c", "cd", "ce"}:
             continue
         elif job.pid is None:
             continue

--- a/src/tomato/daemon/jobdb.py
+++ b/src/tomato/daemon/jobdb.py
@@ -84,13 +84,12 @@ def insert_job(job: Job, dbpath: str) -> int:
     conn.close()
     return ret
 
+
 def update_job_id(id: int, params: dict, dbpath: str) -> Job:
     conn, cur = connect_jobdb(dbpath)
     for k, v in params.items():
         print(f"UPDATE queue SET {k} = {v} WHERE id = {id};")
-        cur.execute(
-            f"UPDATE queue SET {k} = ? WHERE id = {id};", (v,)
-        )
+        cur.execute(f"UPDATE queue SET {k} = ? WHERE id = {id};", (v,))
     conn.commit()
     conn.close()
     return get_job_id(id, dbpath)
@@ -116,23 +115,3 @@ def get_jobs_where(where: str, dbpath: str) -> list[Job]:
     for row in data:
         jobs.append(Job(**{k: v for k, v in zip(columns, row)}))
     return jobs
-
-
-if __name__ == "__main__":
-    dbpath = "testdb.sqlite"
-    #job = Job(payload=payload, submitted_at=str(datetime.now(timezone.utc)), status='qw')
-    # print(job)
-    #id = job_to_db(job, dbpath)
-    #print(db_to_job(id, dbpath))
-    # print(pickle.dumps(payload))
-    # print(job)
-    # j = db_to_job(1, dbpath)
-    # print(j)
-    # j.status = "c"
-    # print(j)
-    # job_to_db(j, dbpath)
-    # print(db_to_job(1, dbpath))
-    #print(db_to_jobs("status='q' OR status='qw'", dbpath))
-    #print(get_job_id(1, dbpath))
-    #print(update_job_id(1, {"status": "c"}, dbpath))
-    print(get_jobs_where("status IS NOT NULL", dbpath))

--- a/src/tomato/daemon/jobdb.py
+++ b/src/tomato/daemon/jobdb.py
@@ -88,7 +88,6 @@ def insert_job(job: Job, dbpath: str) -> int:
 def update_job_id(id: int, params: dict, dbpath: str) -> Job:
     conn, cur = connect_jobdb(dbpath)
     for k, v in params.items():
-        print(f"UPDATE queue SET {k} = {v} WHERE id = {id};")
         cur.execute(f"UPDATE queue SET {k} = ? WHERE id = {id};", (v,))
     conn.commit()
     conn.close()

--- a/src/tomato/daemon/jobdb.py
+++ b/src/tomato/daemon/jobdb.py
@@ -1,3 +1,10 @@
+"""
+**tomato.daemon.jobdb**: the sqlite database for jobs in tomato
+---------------------------------------------------------------
+.. codeauthor::
+    Peter Kraus
+
+"""
 import sqlite3
 import logging
 import os

--- a/src/tomato/daemon/jobdb.py
+++ b/src/tomato/daemon/jobdb.py
@@ -1,0 +1,142 @@
+import sqlite3
+import logging
+import os
+import pickle
+from tomato.models import Job
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+def connect_jobdb(dbpath: str):
+    head, tail = os.path.split(dbpath)
+    if head != "" and not os.path.exists(head):
+        logger.warning("making local data folder '%s'", head)
+        os.makedirs(head)
+    conn = sqlite3.connect(dbpath)
+    cur = conn.cursor()
+    return conn, cur
+
+
+def jobdb_setup(dbpath: str) -> None:
+    user_version = 1
+    conn, cur = connect_jobdb(dbpath)
+    logger.debug("attempting to find table 'queue' in '%s'", dbpath)
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='queue';")
+    exists = bool(len(cur.fetchall()))
+    if exists:
+        logger.debug("table 'queue' present at '%s'", dbpath)
+        cur.execute("PRAGMA user_version;")
+        curr_version = cur.fetchone()[0]
+        # Below is an example of upgrading databases to new user_version:
+        # while curr_version < user_version:
+        #    if curr_version == 0:
+        #        log.info("upgrading table 'queue' from version 0 to 1")
+        #        cur.execute("ALTER TABLE queue ADD COLUMN jobname TEXT;")
+        #        cur.execute("PRAGMA user_version = 1;")
+        #        conn.commit()
+        #    cur.execute("PRAGMA user_version;")
+        #    curr_version = cur.fetchone()[0]
+    else:
+        logger.info("creating a new sqlite3 'queue' table at '%s'", dbpath)
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS queue ("
+            "    id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "    payload BLOB NOT NULL,"
+            "    jobname TEXT,"
+            "    pid INTEGER,"
+            "    status TEXT NOT NULL,"
+            "    submitted_at TEXT NOT NULL,"
+            "    executed_at TEXT,"
+            "    completed_at TEXT,"
+            "    jobpath TEXT,"
+            "    respath TEXT,"
+            "    snappath TEXT"
+            ");",
+        )
+        cur.execute(f"PRAGMA user_version = {user_version};")
+        conn.commit()
+    conn.close()
+
+
+def job_to_db(job: Job, dbpath: str) -> int:
+    conn, cur = connect_jobdb(dbpath)
+    if job.id is None:
+        cur.execute(
+            "INSERT INTO queue (payload, jobname, pid, status, submitted_at, "
+            "executed_at, completed_at, jobpath, respath, snappath)"
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+            (
+                pickle.dumps(job.payload),
+                job.jobname,
+                job.pid,
+                job.status,
+                job.submitted_at,
+                job.executed_at,
+                job.completed_at,
+                job.jobpath,
+                job.respath,
+                job.snappath,
+            ),
+        )
+    else:
+        cur.execute(
+            "UPDATE queue "
+            "SET payload = ?, jobname = ?, pid = ?, status = ?, "
+            "submitted_at = ?, executed_at = ?, completed_at = ?, "
+            "jobpath = ?, respath = ?, snappath = ?"
+            "WHERE id = ?",
+            (
+                pickle.dumps(job.payload),
+                job.jobname,
+                job.pid,
+                job.status,
+                job.submitted_at,
+                job.executed_at,
+                job.completed_at,
+                job.jobpath,
+                job.respath,
+                job.snappath,
+                job.id,
+            ),
+        )
+    conn.commit()
+    cur.execute(f"SELECT id FROM queue WHERE submitted_at = '{job.submitted_at}';")
+    ret = cur.fetchone()[0]
+    conn.close()
+    return ret
+
+
+def db_to_job(id: int, dbpath: str) -> Job:
+    conn, cur = connect_jobdb(dbpath)
+    cur.execute("SELECT * FROM queue WHERE id = ?;", (id,))
+    columns = [i[0] for i in cur.description]
+    data = cur.fetchone()
+    conn.close()
+    j = Job(**{k: v for k, v in zip(columns, data)})
+    return j
+
+
+if __name__ == "__main__":
+    dbpath = "testdb.sqlite"
+    jobdb_setup(dbpath)
+    payload = {
+        "version": "0.2",
+        "sample": {"name": "counter_1_0.1"},
+        "method": [
+            {"device": "counter", "technique": "count", "time": 1.0, "delay": 0.1},
+        ],
+        "tomato": {"verbosity": "DEBUG"},
+    }
+    job = Job(payload=payload, submitted_at=str(datetime.now(timezone.utc)))
+    print(job)
+    id = job_to_db(job, dbpath)
+    print(db_to_job(id, dbpath))
+    # print(pickle.dumps(payload))
+    # print(job)
+    # j = db_to_job(1, dbpath)
+    # print(j)
+    # j.status = "c"
+    # print(j)
+    # job_to_db(j, dbpath)
+    # print(db_to_job(1, dbpath))

--- a/src/tomato/daemon/jobdb.py
+++ b/src/tomato/daemon/jobdb.py
@@ -5,6 +5,7 @@
     Peter Kraus
 
 """
+
 import sqlite3
 import logging
 import os

--- a/src/tomato/daemon/jobdb.py
+++ b/src/tomato/daemon/jobdb.py
@@ -3,7 +3,6 @@ import logging
 import os
 import pickle
 from tomato.models import Job
-from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +27,7 @@ def jobdb_setup(dbpath: str) -> None:
         logger.debug("table 'queue' present at '%s'", dbpath)
         cur.execute("PRAGMA user_version;")
         curr_version = cur.fetchone()[0]
+        assert curr_version == user_version
         # Below is an example of upgrading databases to new user_version:
         # while curr_version < user_version:
         #    if curr_version == 0:

--- a/src/tomato/ketchup/__init__.py
+++ b/src/tomato/ketchup/__init__.py
@@ -168,11 +168,10 @@ def status(
     msg: found 1 job with status ['qw']
     success: true
 
-
     """
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{port}")
-    
+
     if len(jobids) == 0:
         req.send_pyobj(dict(cmd="get_jobs", where="id IS NOT NULL"))
         rets = req.recv_pyobj().data
@@ -247,8 +246,8 @@ def cancel(
     req.connect(f"tcp://127.0.0.1:{port}")
     where = f"id IN ({', '.join([str(j) for j in jobids])})"
     req.send_pyobj(dict(cmd="get_jobs", where=where))
-    jobs = req.recv_pyobj().data
-        
+    jobs = {i.id: i for i in req.recv_pyobj().data}
+
     for jobid in jobids:
         if jobid not in jobs:
             return Reply(success=False, msg=f"job with jobid {jobid} does not exist")

--- a/src/tomato/models.py
+++ b/src/tomato/models.py
@@ -90,7 +90,7 @@ class Job(BaseModel):
             v = pickle.loads(v)
         if isinstance(v, dict):
             v = to_payload(**v)
-        #while hasattr(v, "update"):
+        # while hasattr(v, "update"):
         #    v = v.update()
         return v
 

--- a/src/tomato/models.py
+++ b/src/tomato/models.py
@@ -90,8 +90,8 @@ class Job(BaseModel):
             v = pickle.loads(v)
         if isinstance(v, dict):
             v = to_payload(**v)
-        while hasattr(v, "update"):
-            v = v.update()
+        #while hasattr(v, "update"):
+        #    v = v.update()
         return v
 
 

--- a/src/tomato/models.py
+++ b/src/tomato/models.py
@@ -6,7 +6,7 @@
 """
 
 from pydantic import BaseModel, Field, field_validator
-from typing import Optional, Any, Mapping, Sequence, Literal, Union
+from typing import Optional, Any, Mapping, Sequence, Literal
 from dgbowl_schemas.tomato import to_payload
 from dgbowl_schemas.tomato.payload import Payload
 import logging

--- a/src/tomato/models.py
+++ b/src/tomato/models.py
@@ -7,7 +7,10 @@
 
 from pydantic import BaseModel, Field, field_validator
 from typing import Optional, Any, Mapping, Sequence, Literal, Union
+from dgbowl_schemas.tomato import to_payload
+from dgbowl_schemas.tomato.payload import Payload
 import logging
+import pickle
 
 
 logger = logging.getLogger(__name__)
@@ -70,7 +73,7 @@ class Pipeline(BaseModel):
 
 class Job(BaseModel):
     id: Optional[int] = None
-    payload: Any
+    payload: Payload
     jobname: Optional[str] = None
     pid: Optional[int] = None
     status: Literal["q", "qw", "r", "rd", "c", "cd", "ce"] = "q"
@@ -81,14 +84,15 @@ class Job(BaseModel):
     respath: Optional[str] = None
     snappath: Optional[str] = None
 
-
-class CompletedJob(BaseModel):
-    id: int
-    status: Literal["c", "cd", "ce"]
-    completed_at: str
-    jobname: Optional[str] = None
-    jobpath: str
-    respath: str
+    @field_validator("payload", mode="before")
+    def coerce_payload(cls, v):
+        if isinstance(v, bytes):
+            v = pickle.loads(v)
+        if isinstance(v, dict):
+            v = to_payload(**v)
+        while hasattr(v, "update"):
+            v = v.update()
+        return v
 
 
 class Daemon(BaseModel, arbitrary_types_allowed=True):
@@ -101,8 +105,6 @@ class Daemon(BaseModel, arbitrary_types_allowed=True):
     devs: Mapping[str, Device] = Field(default_factory=dict)
     drvs: Mapping[str, Driver] = Field(default_factory=dict)
     cmps: Mapping[str, Component] = Field(default_factory=dict)
-    jobs: Mapping[int, Union[Job, CompletedJob]] = Field(default_factory=dict)
-    nextjob: int = 1
 
 
 class Reply(BaseModel):

--- a/tests/test_02_ketchup.py
+++ b/tests/test_02_ketchup.py
@@ -171,8 +171,7 @@ def test_ketchup_cancel_queued(pl, datadir, start_tomato_daemon, stop_tomato_dae
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid=pl)
     assert wait_until_ketchup_status(jobid=1, status="qw", port=PORT, timeout=5000)
 
-    status = tomato.status(**kwargs)
-    ret = ketchup.cancel(**kwargs, status=status, verbosity=0, jobids=[1])
+    ret = ketchup.cancel(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
     assert ret.success
     assert ret.data[0].status == "cd"
@@ -192,8 +191,7 @@ def test_ketchup_snapshot(pl, datadir, start_tomato_daemon, stop_tomato_daemon):
     assert wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
 
     assert wait_until_pickle(jobid=1, timeout=2000)
-    status = tomato.status(**kwargs)
-    ret = ketchup.snapshot(jobids=[1], status=status)
+    ret = ketchup.snapshot(jobids=[1], port=PORT, context=CTXT)
     print(f"{ret=}")
     assert ret.success
     assert os.path.exists("snapshot.1.nc")
@@ -202,19 +200,16 @@ def test_ketchup_snapshot(pl, datadir, start_tomato_daemon, stop_tomato_daemon):
 def test_ketchup_search(datadir, start_tomato_daemon, stop_tomato_daemon):
     args = [datadir, start_tomato_daemon, stop_tomato_daemon]
     test_ketchup_submit_two(*args)
-    status = tomato.status(**kwargs)
-    ret = ketchup.search(jobname="2", status=status)
+    ret = ketchup.search(jobname="2", port=PORT, context=CTXT)
     print(f"{ret=}")
     assert ret.success
     assert len(ret.data) == 1
 
-    status = tomato.status(**kwargs)
-    ret = ketchup.search(jobname="job", status=status)
+    ret = ketchup.search(jobname="job", port=PORT, context=CTXT)
     print(f"{ret=}")
     assert ret.success
     assert len(ret.data) == 2
 
-    status = tomato.status(**kwargs)
-    ret = ketchup.search(jobname="wrong", status=status)
+    ret = ketchup.search(jobname="wrong", port=PORT, context=CTXT)
     print(f"{ret=}")
     assert ret.success is False


### PR DESCRIPTION
Rather than storing `Jobs` on `Daemon.jobs`, i.e. in memory, this PR reintroduces `sqlite3` to take care of tracking `Jobs`.

The database can be accessed directly (i.e. using `tomato.daemon.jobdb`) from `tomato-daemon` and `tomato-job` processes, as these always run under the same user. However, job-related operations from `ketchup` should always be routed via `tomato.daemon.cmd.get_job()` or `tomato.daemon.cmd.get_jobs()` to make sure there are no user conflicts.