### PR TITLE
`passata`: Command line tool & API for querying components.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ Repository = "https://github.com/dgbowl/tomato/"
 [project.scripts]
 tomato = "tomato:run_tomato"
 ketchup = "tomato:run_ketchup"
+passata = "tomato:run_passata"
 tomato-job = "tomato.daemon.job:tomato_job"
 tomato-driver = "tomato.daemon.driver:tomato_driver"
 tomato-daemon = "tomato.daemon:tomato_daemon"

--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -311,46 +311,20 @@ def run_passata():
         )
 
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    stats = subparsers.add_parser("status")
+    attrs = subparsers.add_parser("attrs")
+    capbs = subparsers.add_parser("capabilities")
+    gattr = subparsers.add_parser("get")
 
-    cmp = subparsers.add_parser("component")
-    cmp.add_argument(
-        "name",
-        help=(
-            "The Component.name of the component to be queried. "
-            "At least one Component.name has to be provided."
-        ),
-        type=str,
-    )
-    cmp.add_argument(
-        "--attr",
-        "-a",
-        help=(
-            "The attribute of the component to be queried / set. "
-            "When not set, component status is returned."
-        ),
-        type=str,
-        default=None,
-    )
-
-    def float_or_str(string: str):
-        try:
-            return float(string)
-        except ValueError:
-            return string
-
-    cmp.add_argument(
-        "--val",
-        "-v",
-        help=(
-            "The value the attribute of the component to be set to. "
-            "When not set, the current attribute value is returned."
-        ),
-        type=float_or_str,
-        default=None,
-    )
-    cmp.set_defaults(func=passata.component)
-
-    for p in [cmp]:
+    for p in [stats, attrs, capbs, gattr]:
+        p.add_argument(
+            "name",
+            help=(
+                "The Component.name of the component to be queried. "
+                "At least one Component.name has to be provided."
+            ),
+            type=str,
+        )
         p.add_argument(
             "--port",
             "-p",
@@ -371,5 +345,16 @@ def run_passata():
             action="store_true",
             default=False,
         )
+
+    gattr.add_argument(
+        "attrs",
+        help="The attribute name(s) to be queried.",
+        nargs="+",
+    )
+
+    stats.set_defaults(func=passata.status)
+    attrs.set_defaults(func=passata.attrs)
+    capbs.set_defaults(func=passata.capabilities)
+    gattr.set_defaults(func=passata.get_attrs)
 
     parse_args(parser, verbose, is_tomato=False)

--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -8,7 +8,7 @@ import zmq
 import appdirs
 import yaml
 
-from tomato import tomato, ketchup
+from tomato import tomato, ketchup, passata
 
 sys.path += sys.modules["tomato"].__path__
 
@@ -315,12 +315,37 @@ def run_passata():
     cmp = subparsers.add_parser("component")
     cmp.add_argument(
         "name",
-        nargs="+",
         help=(
-            "The Component.name(s) of the component(s) to be queried. "
+            "The Component.name of the component to be queried. "
             "At least one Component.name has to be provided."
         ),
         type=str,
+    )
+    cmp.add_argument(
+        "--attr",
+        "-a",
+        help=(
+            "The attribute of the component to be queried / set. "
+            "When not set, component status is returned."
+        ),
+        type=str,
+        default=None,
+    )
+
+    def float_or_str(string: str):
+        try:
+            return float(string)
+        except ValueError:
+            return string
+
+    cmp.add_argument(
+        "--val",
+        "-v",
+        help=(
+            "The value the attribute of the component to be set to. "
+            "When not set, the current attribute value is returned."
+        ),
+        type=float_or_str,
         default=None,
     )
     cmp.set_defaults(func=passata.component)

--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -281,7 +281,7 @@ def run_ketchup():
             default=False,
         )
 
-    parse_args(parse, verbose, is_tomato=False)
+    parse_args(parser, verbose, is_tomato=False)
 
 
 def run_passata():
@@ -314,7 +314,7 @@ def run_passata():
 
     cmp = subparsers.add_parser("component")
     cmp.add_argument(
-        "component",
+        "name",
         nargs="+",
         help=(
             "The Component.name(s) of the component(s) to be queried. "
@@ -347,4 +347,4 @@ def run_passata():
             default=False,
         )
 
-    parse_args(parse, verbose, is_tomato=False)
+    parse_args(parser, verbose, is_tomato=False)

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -149,3 +149,24 @@ def set_attr(
     )
     ret = req.recv_pyobj()
     return ret
+
+
+def reset(
+    *,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
+        return ret
+    cmp, drv = ret
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
+    req.send_pyobj(dict(cmd="dev_reset", params=kwargs))
+    ret = req.recv_pyobj()
+    return ret

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -1,19 +1,15 @@
 import zmq
 from tomato import tomato
-from tomato.models import Reply
+from tomato.models import Reply, Component, Driver
 from typing import Any
 
 
-def component(
-    *,
+def _name_to_cmp(
+    name: str,
     port: int,
     timeout: int,
     context: zmq.Context,
-    name: str,
-    attr: str = None,
-    val: Any = None,
-    **_: dict,
-) -> Reply:
+) -> tuple[Component, Driver]:
     ret = tomato.status(
         port=port, timeout=timeout, context=context, stgrp="tom", yaml=True
     )
@@ -27,28 +23,111 @@ def component(
         )
     cmp = ret.data.cmps[name]
     drv = ret.data.drvs[cmp.driver]
+    return cmp, drv 
+
+
+def status(
+    *,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
+        return ret
+    cmp, drv = ret
+
     kwargs = dict(channel=cmp.channel, address=cmp.address)
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{drv.port}")
-    if attr is None:
-        req.send_pyobj(dict(cmd="dev_status", params={**kwargs}))
-        ret = req.recv_pyobj()
-        req.close()
+    req.send_pyobj(dict(cmd="dev_status", params={**kwargs}))
+    ret = req.recv_pyobj()
+    req.close()
+    return ret
+
+
+def attrs(
+    *,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
         return ret
+    cmp, drv = ret
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
     req.send_pyobj(dict(cmd="attrs", params={**kwargs}))
     ret = req.recv_pyobj()
-    if attr is True:
+    return ret
+
+
+def capabilities(
+    *,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
         return ret
-    if attr not in ret.data:
-        return Reply(
-            success=False,
-            msg=f"attr {attr!r} not accessible on component {name!r}",
-            data=ret.data,
-        )
-    if val is None:
-        req.send_pyobj(dict(cmd="dev_get_attr", params={"attr": attr, **kwargs}))
-        ret = req.recv_pyobj()
+    cmp, drv = ret
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
+    req.send_pyobj(dict(cmd="capabilities", params={**kwargs}))
+    ret = req.recv_pyobj()
+    return ret
+
+
+def get_attr(
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    attr: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
         return ret
+    cmp, drv = ret
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
+    req.send_pyobj(dict(cmd="dev_get_attr", params={"attr": attr, **kwargs}))
+    ret = req.recv_pyobj()
+    return ret
+
+
+def set_attr(
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    attr: str,
+    val: Any,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
+        return ret
+    cmp, drv = ret
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
     req.send_pyobj(
         dict(cmd="dev_set_attr", params={"attr": attr, "val": val, **kwargs})
     )
@@ -59,63 +138,60 @@ def component(
 if __name__ == "__main__":
     import random
 
-    ret = component(
-        port=1234,
-        timeout=1000,
-        context=zmq.Context(),
+    kwargs = dict(port=1234, timeout=1000, context=zmq.Context())
+    ret = status(
         name="example_counter:(example-addr,1)",
+        **kwargs,
     )
     print(ret.data)
-    ret = component(
-        port=1234, timeout=1000, context=zmq.Context(), name="psutil:(psutil-addr,1)"
-    )
-    print(ret.data)
-    ret = component(
-        port=1234,
-        timeout=1000,
-        context=zmq.Context(),
+    ret = status(
         name="psutil:(psutil-addr,1)",
-        attr=True,
+        **kwargs,
     )
     print(ret.data)
-    ret = component(
-        port=1234,
-        timeout=1000,
-        context=zmq.Context(),
+    ret = attrs(
+        name="psutil:(psutil-addr,1)",
+        **kwargs,
+    )
+    print(ret.data)
+    ret = capabilities(
+        name="psutil:(psutil-addr,1)",
+        **kwargs,
+    )
+    
+    print(ret.data)
+    ret = get_attr(
         name="psutil:(psutil-addr,1)",
         attr="cpu_count",
+        **kwargs,
     )
     print(ret.data)
-    ret = component(
-        port=1234,
-        timeout=1000,
-        context=zmq.Context(),
+    ret = attrs(
         name="example_counter:(example-addr,1)",
-        attr=True,
+        **kwargs,
     )
     print(ret.data)
-    ret = component(
-        port=1234,
-        timeout=1000,
-        context=zmq.Context(),
+    ret = capabilities(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    print(ret.data)
+    ret = get_attr(
         name="example_counter:(example-addr,1)",
         attr="max",
+        **kwargs,
     )
     print(ret.data)
-    ret = component(
-        port=1234,
-        timeout=1000,
-        context=zmq.Context(),
+    ret = set_attr(
         name="example_counter:(example-addr,1)",
         attr="max",
         val=random.random() * 10,
+        **kwargs
     )
     print(ret.data)
-    ret = component(
-        port=1234,
-        timeout=1000,
-        context=zmq.Context(),
+    ret = get_attr(
         name="example_counter:(example-addr,1)",
         attr="max",
+        **kwargs
     )
     print(ret.data)

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -1,11 +1,121 @@
 import zmq
+from tomato import tomato
+from tomato.models import Reply
+from typing import Any
 
 
 def component(
     *,
     port: int,
+    timeout: int,
     context: zmq.Context,
     name: str,
+    attr: str = None,
+    val: Any = None,
     **_: dict,
 ) -> Reply:
-    pass
+    ret = tomato.status(
+        port=port, timeout=timeout, context=context, stgrp="tom", yaml=True
+    )
+    if not ret.success:
+        return ret
+    if name not in ret.data.cmps:
+        return Reply(
+            success=False,
+            msg=f"component {name!r} not found on tomato",
+            data=ret.data,
+        )
+    cmp = ret.data.cmps[name]
+    drv = ret.data.drvs[cmp.driver]
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
+    if attr is None:
+        req.send_pyobj(dict(cmd="dev_status", params={**kwargs}))
+        ret = req.recv_pyobj()
+        req.close()
+        return ret
+    req.send_pyobj(dict(cmd="attrs", params={**kwargs}))
+    ret = req.recv_pyobj()
+    if attr is True:
+        return ret
+    if attr not in ret.data:
+        return Reply(
+            success=False,
+            msg=f"attr {attr!r} not accessible on component {name!r}",
+            data=ret.data,
+        )
+    if val is None:
+        req.send_pyobj(dict(cmd="dev_get_attr", params={"attr": attr, **kwargs}))
+        ret = req.recv_pyobj()
+        return ret
+    req.send_pyobj(
+        dict(cmd="dev_set_attr", params={"attr": attr, "val": val, **kwargs})
+    )
+    ret = req.recv_pyobj()
+    return ret
+
+
+if __name__ == "__main__":
+    import random
+
+    ret = component(
+        port=1234,
+        timeout=1000,
+        context=zmq.Context(),
+        name="example_counter:(example-addr,1)",
+    )
+    print(ret.data)
+    ret = component(
+        port=1234, timeout=1000, context=zmq.Context(), name="psutil:(psutil-addr,1)"
+    )
+    print(ret.data)
+    ret = component(
+        port=1234,
+        timeout=1000,
+        context=zmq.Context(),
+        name="psutil:(psutil-addr,1)",
+        attr=True,
+    )
+    print(ret.data)
+    ret = component(
+        port=1234,
+        timeout=1000,
+        context=zmq.Context(),
+        name="psutil:(psutil-addr,1)",
+        attr="cpu_count",
+    )
+    print(ret.data)
+    ret = component(
+        port=1234,
+        timeout=1000,
+        context=zmq.Context(),
+        name="example_counter:(example-addr,1)",
+        attr=True,
+    )
+    print(ret.data)
+    ret = component(
+        port=1234,
+        timeout=1000,
+        context=zmq.Context(),
+        name="example_counter:(example-addr,1)",
+        attr="max",
+    )
+    print(ret.data)
+    ret = component(
+        port=1234,
+        timeout=1000,
+        context=zmq.Context(),
+        name="example_counter:(example-addr,1)",
+        attr="max",
+        val=random.random() * 10,
+    )
+    print(ret.data)
+    ret = component(
+        port=1234,
+        timeout=1000,
+        context=zmq.Context(),
+        name="example_counter:(example-addr,1)",
+        attr="max",
+    )
+    print(ret.data)

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -96,7 +96,7 @@ def get_attrs(
     context: zmq.Context,
     name: str,
     attrs: list[str],
-    yaml: bool,
+    yaml: bool = False,
     **_: dict,
 ) -> Reply:
     ret = _name_to_cmp(name, port, timeout, context)

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -1,0 +1,11 @@
+import zmq
+
+
+def component(
+    *,
+    port: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    pass

--- a/tests/test_02_ketchup.py
+++ b/tests/test_02_ketchup.py
@@ -44,8 +44,7 @@ def test_ketchup_submit_two(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 def test_ketchup_status_empty(start_tomato_daemon, stop_tomato_daemon):
     assert wait_until_tomato_running(port=PORT, timeout=5000)
-    status = tomato.status(**kwargs)
-    ret = ketchup.status(**kwargs, status=status, verbosity=0, jobids=[])
+    ret = ketchup.status(**kwargs, verbosity=0, jobids=[])
     print(f"{ret=}")
     assert not ret.success
     assert "job queue is empty" in ret.msg
@@ -54,8 +53,7 @@ def test_ketchup_status_empty(start_tomato_daemon, stop_tomato_daemon):
 def test_ketchup_status_all_queued(datadir, start_tomato_daemon, stop_tomato_daemon):
     args = [datadir, start_tomato_daemon, stop_tomato_daemon]
     test_ketchup_submit_two(*args)
-    status = tomato.status(**kwargs)
-    ret = ketchup.status(**kwargs, status=status, verbosity=0, jobids=[])
+    ret = ketchup.status(**kwargs, verbosity=0, jobids=[])
     print(f"{ret=}")
     assert ret.success
     assert "found 2" in ret.msg
@@ -65,8 +63,7 @@ def test_ketchup_status_all_queued(datadir, start_tomato_daemon, stop_tomato_dae
 def test_ketchup_status_one_queued(datadir, start_tomato_daemon, stop_tomato_daemon):
     args = [datadir, start_tomato_daemon, stop_tomato_daemon]
     test_ketchup_submit_two(*args)
-    status = tomato.status(**kwargs)
-    ret = ketchup.status(**kwargs, status=status, verbosity=0, jobids=[2])
+    ret = ketchup.status(**kwargs, verbosity=0, jobids=[2])
     print(f"{ret=}")
     assert ret.success
     assert "found 1" in ret.msg
@@ -77,8 +74,8 @@ def test_ketchup_status_one_queued(datadir, start_tomato_daemon, stop_tomato_dae
 def test_ketchup_status_two_queued(datadir, start_tomato_daemon, stop_tomato_daemon):
     args = [datadir, start_tomato_daemon, stop_tomato_daemon]
     test_ketchup_submit_two(*args)
-    status = tomato.status(**kwargs)
-    ret = ketchup.status(**kwargs, status=status, verbosity=0, jobids=[1, 2])
+    wait_until_ketchup_status(jobid=2, status="q", port=PORT, timeout=1000)
+    ret = ketchup.status(**kwargs, verbosity=0, jobids=[1, 2])
     print(f"{ret=}")
     assert ret.success
     assert "found 2" in ret.msg
@@ -99,8 +96,7 @@ def test_ketchup_status_running(pl, datadir, start_tomato_daemon, stop_tomato_da
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid=pl)
     tomato.pipeline_ready(**kwargs, pipeline="pip-counter")
     wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
-    status = tomato.status(**kwargs)
-    ret = ketchup.status(**kwargs, status=status, verbosity=0, jobids=[1])
+    ret = ketchup.status(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
     assert ret.success
     assert "found 1" in ret.msg
@@ -120,8 +116,7 @@ def test_ketchup_status_complete(pl, datadir, start_tomato_daemon, stop_tomato_d
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid=pl)
     tomato.pipeline_ready(**kwargs, pipeline="pip-counter")
     assert wait_until_ketchup_status(jobid=1, status="c", port=PORT, timeout=5000)
-    status = tomato.status(**kwargs)
-    ret = ketchup.status(**kwargs, status=status, verbosity=0, jobids=[1])
+    ret = ketchup.status(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
     assert ret.success
     assert ret.data[0].status == "c"
@@ -142,15 +137,13 @@ def test_ketchup_cancel_running(pl, datadir, start_tomato_daemon, stop_tomato_da
     assert wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
 
     assert wait_until_pickle(jobid=1, timeout=2000)
-    status = tomato.status(**kwargs)
-    ret = ketchup.cancel(**kwargs, status=status, verbosity=0, jobids=[1])
+    ret = ketchup.cancel(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
     assert ret.success
     assert ret.data[0].status == "rd"
 
     assert wait_until_ketchup_status(jobid=1, status="cd", port=PORT, timeout=5000)
-    status = tomato.status(**kwargs)
-    ret = ketchup.status(**kwargs, status=status, verbosity=0, jobids=[1])
+    ret = ketchup.status(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
     print(f"{os.listdir()=}")
     print(f"{os.listdir('Jobs')=}")

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -13,7 +13,10 @@ kwargs = dict(port=PORT, timeout=TIME, context=CTXT)
 
 def test_passata_api_status(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=3000)
-    ret = tomato.passata.status(name="example_counter:(example-addr,1)", **kwargs)
+    ret = tomato.passata.status(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
     print(f"{ret=}")
     assert ret.success
     assert "running" in ret.data
@@ -21,7 +24,10 @@ def test_passata_api_status(start_tomato_daemon, stop_tomato_daemon):
 
 def test_passata_api_attrs(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=3000)
-    ret = tomato.passata.attrs(name="example_counter:(example-addr,1)", **kwargs)
+    ret = tomato.passata.attrs(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
     print(f"{ret=}")
     assert ret.success
     assert "max" in ret.data
@@ -29,7 +35,10 @@ def test_passata_api_attrs(start_tomato_daemon, stop_tomato_daemon):
 
 def test_passata_api_capabs(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=3000)
-    ret = tomato.passata.capabilities(name="example_counter:(example-addr,1)", **kwargs)
+    ret = tomato.passata.capabilities(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
     print(f"{ret=}")
     assert ret.success
     assert "count" in ret.data
@@ -38,7 +47,9 @@ def test_passata_api_capabs(start_tomato_daemon, stop_tomato_daemon):
 def test_passata_api_get_attrs(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=3000)
     ret = tomato.passata.get_attrs(
-        name="example_counter:(example-addr,1)", attrs=["max", "min"], **kwargs
+        name="example_counter:(example-addr,1)",
+        attrs=["max", "min"],
+        **kwargs,
     )
     print(f"{ret=}")
     assert ret.success
@@ -50,17 +61,32 @@ def test_passata_api_set_attr(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=3000)
     val = random.random() * 100
     ret = tomato.passata.set_attr(
-        name="example_counter:(example-addr,1)", attr="max", val=val, **kwargs
+        name="example_counter:(example-addr,1)",
+        attr="max",
+        val=val,
+        **kwargs,
     )
     print(f"{ret=}")
     assert ret.success
     assert ret.data == val
     ret = tomato.passata.get_attrs(
-        name="example_counter:(example-addr,1)", attrs=["max"], **kwargs
+        name="example_counter:(example-addr,1)",
+        attrs=["max"],
+        **kwargs,
     )
     print(f"{ret=}")
     assert ret.success
     assert ret.data["max"] == val
+
+
+def test_passata_api_reset(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = tomato.passata.reset(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    print(f"{ret=}")
+    assert ret.success
 
 
 def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -1,0 +1,64 @@
+import pytest
+import os
+import zmq
+import random
+
+from . import utils
+import tomato
+
+PORT = 12345
+TIME = 1000
+CTXT = zmq.Context()
+kwargs = dict(port=PORT, timeout=TIME, context=CTXT)
+
+
+def test_passata_api_status(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = tomato.passata.status(name="example_counter:(example-addr,1)", **kwargs)
+    print(f"{ret=}")
+    assert ret.success
+    assert "running" in ret.data
+
+
+def test_passata_api_attrs(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = tomato.passata.attrs(name="example_counter:(example-addr,1)", **kwargs)
+    print(f"{ret=}")
+    assert ret.success
+    assert "max" in ret.data
+
+
+def test_passata_api_capabs(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = tomato.passata.capabilities(name="example_counter:(example-addr,1)", **kwargs)
+    print(f"{ret=}")
+    assert ret.success
+    assert "count" in ret.data
+
+
+def test_passata_api_get_attrs(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = tomato.passata.get_attrs(
+        name="example_counter:(example-addr,1)", attrs=["max", "min"], **kwargs
+    )
+    print(f"{ret=}")
+    assert ret.success
+    assert "max" in ret.data
+    assert "min" in ret.data
+
+
+def test_passata_api_set_attr(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    val = random.random() * 100
+    ret = tomato.passata.set_attr(
+        name="example_counter:(example-addr,1)", attr="max", val=val, **kwargs
+    )
+    print(f"{ret=}")
+    assert ret.success
+    assert ret.data == val
+    ret = tomato.passata.get_attrs(
+        name="example_counter:(example-addr,1)", attrs=["max"], **kwargs
+    )
+    print(f"{ret=}")
+    assert ret.success
+    assert ret.data["max"] == val

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -1,7 +1,6 @@
-import pytest
-import os
 import zmq
 import random
+import subprocess
 
 from . import utils
 import tomato
@@ -62,3 +61,69 @@ def test_passata_api_set_attr(start_tomato_daemon, stop_tomato_daemon):
     print(f"{ret=}")
     assert ret.success
     assert ret.data["max"] == val
+
+
+def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = subprocess.run(
+        [
+            "passata",
+            "status",
+            "example_counter:(example-addr,1)",
+            "-p",
+            f"{PORT}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    print(f"{ret=}")
+    assert "Success: component ('example-addr', '1')" in ret.stdout
+
+    ret = subprocess.run(
+        [
+            "passata",
+            "attrs",
+            "example_counter:(example-addr,1)",
+            "-p",
+            f"{PORT}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    print(f"{ret=}")
+    assert "Success: attrs of component ('example-addr', '1') are" in ret.stdout
+
+    ret = subprocess.run(
+        [
+            "passata",
+            "capabilities",
+            "example_counter:(example-addr,1)",
+            "-p",
+            f"{PORT}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    print(f"{ret=}")
+    assert (
+        "Success: capabilities supported by component ('example-addr', '1') are"
+        in ret.stdout
+    )
+
+    ret = subprocess.run(
+        [
+            "passata",
+            "get",
+            "example_counter:(example-addr,1)",
+            "max",
+            "-p",
+            f"{PORT}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    print(f"{ret=}")
+    assert (
+        "Success: attr 'max' of component 'example_counter:(example-addr,1)' is"
+        in ret.stdout
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,6 +66,7 @@ def wait_until_ketchup_status(jobid: int, status: str, port: int, timeout: int):
             capture_output=True,
             text=True,
         )
+        print(f"{ret.stdout=}")
         if f"[{status!r}]" in ret.stdout:
             return True
         time.sleep(0.5)


### PR DESCRIPTION
`passata` is a new CLI utility and python module containing an API for interaction directly with driver processes, allowing users to query components.  

The CLI interface will probably be read-only (i.e. access to `dev_status`, `attrs`, `capabilities`, and `dev_get_attr`), while the API will allow functional access also to the `dev_set_attr`, and `reset` entrypoints of the driver process.