### PR TITLE
Fix `tomato status` syntax

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -79,7 +79,7 @@ The :mod:`tomato.tomato` executable is used to configure, start, and manage the 
 
             .. code-block:: bash
 
-                >>> tomato status --pipeline
+                >>> tomato status pipelines
 
 
         - For loading a sample into a *pipeline*:

--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -12,7 +12,7 @@ Changes from ``tomato-1.0`` include:
 
 - *jobs* are now tracked in a queue stored in a ``sqlite3`` database instead of on the ``tomato.daemon``.
 - ``logdir`` can now be set in *settings file*, with the default value configurable using ``tomato init``.
-- ``tomato status`` now supports further arguments: ``--pipelines``, ``--drivers``, ``--devices``, and ``--components`` can be used to query status of subsets of the running **tomato**
+- ``tomato status`` now supports further arguments: ``pipelines``, ``drivers``, ``devices``, and ``components`` can be used to query status of subsets of the running **tomato**.
 
 .. codeauthor::
     Peter Kraus

--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -38,7 +38,7 @@ def run_tomato():
 
     status = subparsers.add_parser("status")
     status.add_argument(
-        "status",
+        "stgrp",
         choices=["tomato", "pipelines", "drivers", "devices", "components"],
         default="tomato",
         nargs="?",

--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -37,27 +37,12 @@ def run_tomato():
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
     status = subparsers.add_parser("status")
-    stgrp = status.add_mutually_exclusive_group()
-    grpargs = dict(dest="stgrp", action="store_const")
-    stgrp.add_argument(
-        "--tomato",
-        "--tom",
-        **grpargs,
-        const="tom",
-        help="Show tomato status.",
-        default="tom",
-    )
-    stgrp.add_argument(
-        "--pipelines", "--pip", **grpargs, const="pip", help="Show tomato pipelines."
-    )
-    stgrp.add_argument(
-        "--drivers", "--drv", **grpargs, const="drv", help="Show tomato drivers."
-    )
-    stgrp.add_argument(
-        "--devices", "--dev", **grpargs, const="dev", help="Show tomato devices."
-    )
-    stgrp.add_argument(
-        "--components", "--cmp", **grpargs, const="cmp", help="Show tomato components."
+    status.add_argument(
+        "status",
+        choices=["tomato", "pipelines", "drivers", "devices", "components"],
+        default="tomato",
+        nargs="?",
+        help="Check status of 'tomato', or its 'pipelines', 'drivers', 'devices', or 'components'.",
     )
     status.set_defaults(func=tomato.status)
 

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -225,7 +225,7 @@ def status(
     port: int,
     timeout: int,
     context: zmq.Context,
-    status: str = "tomato",
+    stgrp: str = "tomato",
     yaml: bool = True,
     **_: dict,
 ) -> Reply:
@@ -297,7 +297,7 @@ def status(
     events = dict(poller.poll(timeout))
     if req in events:
         rep = req.recv_pyobj()
-        return _status_helper(daemon=rep.data, yaml=yaml, stgrp=status)
+        return _status_helper(daemon=rep.data, yaml=yaml, stgrp=stgrp)
     else:
         req.setsockopt(zmq.LINGER, 0)
         req.close()

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -268,22 +268,22 @@ def status(
     success: true
 
     >>> # Status of all configured pipelines
-    >>> tomato status --pipeline
+    >>> tomato status pipelines
     Success: tomato running on port 1234 with the following pipelines:
          name:pip-counter       ready:False     sampleid:counter_1_0.1  jobid:None
 
     >>> # Status of all configured drivers
-    >>> tomato status --drivers
+    >>> tomato status drivers
     Success: tomato running on port 1234 with the following drivers:
          name:example_counter   port:34747      pid:192318
 
     >>> # Status of all configured devices
-    >>> tomato status --devices
+    >>> tomato status devices
     Success: tomato running on port 1234 with the following devices:
          name:dev-counter       driver:example_counter  address:example-addr    channels:['1']
 
     >>> # Status of all configured components:
-    >>> tomato status --components
+    >>> tomato status components
     Success: tomato running on port 1234 with the following components:
          name:example_counter:(example-addr,1)  driver:example_counter  device:dev-counter      role:counter
 

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -139,13 +139,13 @@ def _updater(context, port, cmd, params):
 
 
 def _status_helper(daemon: Daemon, yaml: bool, stgrp: str):
-    if stgrp == "tom":
+    if stgrp == "tomato":
         rep = Reply(
             success=True,
             msg=f"tomato running on port {daemon.port}",
             data=daemon,
         )
-    elif stgrp == "pip":
+    elif stgrp == "pipelines":
         if yaml:
             rep = Reply(
                 success=True,
@@ -163,7 +163,7 @@ def _status_helper(daemon: Daemon, yaml: bool, stgrp: str):
                 msg = f"tomato running on port {daemon.port} with the following pipelines:\n\t "
                 msg += "\n\t ".join(ii)
             rep = Reply(success=True, msg=msg)
-    elif stgrp == "drv":
+    elif stgrp == "drivers":
         if yaml:
             rep = Reply(
                 success=True,
@@ -181,7 +181,7 @@ def _status_helper(daemon: Daemon, yaml: bool, stgrp: str):
                 msg = f"tomato running on port {daemon.port} with the following drivers:\n\t "
                 msg += "\n\t ".join(ii)
             rep = Reply(success=True, msg=msg)
-    elif stgrp == "dev":
+    elif stgrp == "devices":
         if yaml:
             rep = Reply(
                 success=True,
@@ -199,7 +199,7 @@ def _status_helper(daemon: Daemon, yaml: bool, stgrp: str):
                 msg = f"tomato running on port {daemon.port} with the following devices:\n\t "
                 msg += "\n\t ".join(ii)
             rep = Reply(success=True, msg=msg)
-    elif stgrp == "cmp":
+    elif stgrp == "components":
         if yaml:
             rep = Reply(
                 success=True,
@@ -225,7 +225,7 @@ def status(
     port: int,
     timeout: int,
     context: zmq.Context,
-    stgrp: str = "tom",
+    status: str = "tomato",
     yaml: bool = True,
     **_: dict,
 ) -> Reply:
@@ -297,7 +297,7 @@ def status(
     events = dict(poller.poll(timeout))
     if req in events:
         rep = req.recv_pyobj()
-        return _status_helper(daemon=rep.data, yaml=yaml, stgrp=stgrp)
+        return _status_helper(daemon=rep.data, yaml=yaml, stgrp=status)
     else:
         req.setsockopt(zmq.LINGER, 0)
         req.close()


### PR DESCRIPTION
Instead of optional arguments (`--pipelines`, `--components` etc.), let's add a positional argument that defaults to `tomato` instead.