### PR TITLE
Implement `constants` in `DriverInterface-2.0`

### DIFF
--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -10,9 +10,12 @@ Developed at the ConCat lab at TU Berlin.
 
 Changes from ``tomato-1.0`` include:
 
-- *jobs* are now tracked in a queue stored in a ``sqlite3`` database instead of on the ``tomato.daemon``.
-- ``logdir`` can now be set in *settings file*, with the default value configurable using ``tomato init``.
-- ``tomato status`` now supports further arguments: ``pipelines``, ``drivers``, ``devices``, and ``components`` can be used to query status of subsets of the running **tomato**.
+- *Jobs* are now tracked in a queue stored in a ``sqlite3`` database instead of on the ``tomato.daemon``.
+- The ``logdir`` can now be set in *settings file*, with the default value configurable using ``tomato init``.
+- The ``tomato status`` command now supports further arguments: ``pipelines``, ``drivers``, ``devices``, and ``components`` can be used to query status of subsets of the running **tomato**.
+- A new ``passata`` command and :mod:`tomato.passata` module for interacting with *components* over CLI and API.
+- A new ``DriverInterface-2.0``, with the following changes:
+  - ``constants``: a container for constant *driver* and *component*-specific metadata
 
 .. codeauthor::
     Peter Kraus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
 [project.optional-dependencies]
 testing = [
     "pytest",
-    "tomato-example-counter >= 1.0.0",
+    # "tomato-example-counter >= 1.0.0",
+    "tomato-example-counter @ git+https://github.com/dgbowl/tomato-example-counter.git@driver_2.0",
     "tomato-psutil >= 1.0.0",
 ]
 docs = [

--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -314,9 +314,10 @@ def run_passata():
     stats = subparsers.add_parser("status")
     attrs = subparsers.add_parser("attrs")
     capbs = subparsers.add_parser("capabilities")
+    const = subparsers.add_parser("constants")
     gattr = subparsers.add_parser("get")
 
-    for p in [stats, attrs, capbs, gattr]:
+    for p in [stats, attrs, capbs, gattr, const]:
         p.add_argument(
             "name",
             help=(
@@ -355,6 +356,7 @@ def run_passata():
     stats.set_defaults(func=passata.status)
     attrs.set_defaults(func=passata.attrs)
     capbs.set_defaults(func=passata.capabilities)
+    const.set_defaults(func=passata.constants)
     gattr.set_defaults(func=passata.get_attrs)
 
     parse_args(parser, verbose, is_tomato=False)

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -15,15 +15,18 @@ from importlib import metadata
 from datetime import datetime, timezone
 from threading import current_thread
 from pathlib import Path
+from typing import Union
 
 import zmq
 import psutil
 
-from tomato.driverinterface_1_0 import ModelInterface
+from tomato.driverinterface_1_0 import ModelInterface as MI_1_0
+from tomato.driverinterface_2_0 import ModelInterface as MI_2_0
 from tomato.drivers import driver_to_interface
 from tomato.models import Reply
 
 logger = logging.getLogger(__name__)
+ModelInterface = Union[MI_1_0, MI_2_0]
 
 
 def tomato_driver_bootstrap(
@@ -131,6 +134,7 @@ def tomato_driver() -> None:
         port=port,
         pid=pid,
         connected_at=str(datetime.now(timezone.utc)),
+        version=interface.version,
         settings=interface.settings,
     )
     req.send_pyobj(

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -1,0 +1,498 @@
+from abc import ABCMeta, abstractmethod
+from typing import TypeVar, Any
+from pydantic import BaseModel
+from threading import Thread, current_thread, RLock
+from queue import Queue
+from tomato.models import Reply
+from dgbowl_schemas.tomato.payload import Task
+import logging
+from functools import wraps
+from xarray import Dataset
+from collections import defaultdict
+import time
+import atexit
+
+logger = logging.getLogger(__name__)
+
+
+def in_devmap(func):
+    @wraps(func)
+    def wrapper(self, **kwargs):
+        if "key" in kwargs:
+            key = kwargs.pop("key")
+        else:
+            address = kwargs.get("address")
+            channel = kwargs.get("channel")
+            key = (address, channel)
+        if key not in self.devmap:
+            msg = f"dev with address {address!r} and channel {channel} is unknown"
+            return Reply(success=False, msg=msg, data=self.devmap.keys())
+        return func(self, **kwargs, key=key)
+
+    return wrapper
+
+
+T = TypeVar("T")
+
+
+class Attr(BaseModel):
+    """A Pydantic :class:`BaseModel` used to describe device attributes."""
+
+    type: T
+    rw: bool = False
+    status: bool = False
+    units: str = None
+
+
+class ModelInterface(metaclass=ABCMeta):
+    """
+    An abstract base class specifying the driver interface.
+
+    Individual driver modules should expose a :class:`DriverInterface` which inherits
+    from this abstract class. Only the methods of this class should be used to interact
+    with drivers and their devices.
+    """
+
+    version: str = "2.0"
+
+    @abstractmethod
+    def CreateDeviceManager(self, key, **kwargs):
+        """
+        A factory function which is used to pass this instance of the :class:`ModelInterface`
+        to the new :class:`DeviceManager` instance.
+        """
+        pass
+
+    devmap: dict[tuple, "ModelInterface"]
+    """Map of registered devices, the tuple keys are `component = (address, channel)`"""
+
+    settings: dict[str, Any]
+    """A settings map to contain driver-specific settings such as `dllpath` for BioLogic"""
+
+    constants: dict[str, Any]
+    """A map that should be populated with driver-specific run-time constants."""
+
+    def __init__(self, settings=None):
+        self.devmap = {}
+        self.settings = settings if settings is not None else {}
+
+    def dev_register(self, address: str, channel: str, **kwargs: dict) -> Reply:
+        """
+        Register a new device component in this driver.
+
+        Creates a :class:`DeviceManager` representing a device component, storing it in
+        the :obj:`self.devmap` using the provided `address` and `channel`.
+
+        The returned :class:`Reply` should contain the capabilities of the registered
+        component in the ``data`` slot.
+        """
+        key = (address, channel)
+        self.devmap[key] = self.CreateDeviceManager(key, **kwargs)
+        capabs = self.devmap[key].capabilities()
+        return Reply(
+            success=True,
+            msg=f"device {key!r} registered",
+            data=capabs,
+        )
+
+    @in_devmap
+    def dev_teardown(self, key: tuple, **kwargs: dict) -> Reply:
+        """
+        Emergency stop function.
+
+        Should set the device component into a documented, safe state. The function is
+        to be only called in case of critical errors, or when the component is being
+        removed, not as part of normal operation (i.e. it is not intended as a clean-up
+        after task completion).
+        """
+        status = self.task_status(key=key, **kwargs)
+        if status.data:
+            logger.warning("tearing down component %s with a running task!", key)
+            self.task_stop(key=key, **kwargs)
+        self.dev_reset(key=key, **kwargs)
+        del self.devmap[key]
+        return Reply(
+            success=True,
+            msg=f"device {key!r} torn down",
+        )
+
+    @in_devmap
+    def dev_reset(self, key: tuple, **kwargs: dict) -> Reply:
+        """
+        Component reset function.
+
+        Should set the device component into a documented, safe state. This function
+        is executed at the end of every job.
+        """
+        self.devmap[key].reset()
+        return Reply(
+            success=True,
+            msg=f"component {key!r} reset successfully",
+        )
+
+    @in_devmap
+    def dev_set_attr(self, attr: str, val: Any, key: tuple, **kwargs: dict) -> Reply:
+        """
+        Set value of the :class:`Attr` of the specified device component.
+
+        Pass-through to the :func:`DeviceManager.set_attr` function. No type or
+        read-write validation performed here!
+        """
+        self.devmap[key].set_attr(attr=attr, val=val, **kwargs)
+        return Reply(
+            success=True,
+            msg=f"attr {attr!r} of component {key} set to {val}",
+            data=val,
+        )
+
+    @in_devmap
+    def dev_get_attr(self, attr: str, key: tuple, **kwargs: dict) -> Reply:
+        """
+        Get value of the :class:`Attr` from the specified device component.
+
+        Pass-through to the :func:`DeviceManager.get_attr` function. Units are not
+        returned; those can be queried for all :class:`Attrs` using :func:`self.attrs`.
+
+        """
+        ret = self.devmap[key].get_attr(attr=attr, **kwargs)
+        return Reply(
+            success=True,
+            msg=f"attr {attr!r} of component {key} is: {ret}",
+            data=ret,
+        )
+
+    @in_devmap
+    def dev_status(self, key: tuple, **kwargs: dict) -> Reply:
+        """
+        Get the status report from the specified device component.
+
+        Iterates over all :class:`Attrs` on the component that have ``status=True`` and
+        returns their values in the :obj:`Reply.data` as a :class:`dict`.
+        """
+        ret = {}
+        for k, attr in self.devmap[key].attrs(key=key, **kwargs).items():
+            if attr.status:
+                ret[k] = self.devmap[key].get_attr(attr=k, **kwargs)
+
+        ret["running"] = self.devmap[key].running
+        return Reply(
+            success=True,
+            msg=f"component {key} is{' ' if ret['running'] else ' not '}running",
+            data=ret,
+        )
+
+    @in_devmap
+    def dev_capabilities(self, key: tuple, **kwargs) -> Reply:
+        """
+        Returns the capabilities of the device component.
+
+        Pass-through to :func:`DriverManager.capabilities`.
+        """
+        ret = self.devmap[key].capabilities(**kwargs)
+        return Reply(
+            success=True,
+            msg=f"capabilities supported by component {key!r} are: {ret}",
+            data=ret,
+        )
+
+    @in_devmap
+    def dev_attrs(self, key: tuple, **kwargs: dict) -> Reply:
+        """
+        Query available :class:`Attrs` on the specified device component.
+
+        Pass-through to the :func:`DeviceManager.attrs` function.
+        """
+        ret = self.devmap[key].attrs(**kwargs)
+        return Reply(
+            success=True,
+            msg=f"attrs of component {key!r} are: {ret}",
+            data=ret,
+        )
+
+    @in_devmap
+    def dev_get_data(self, key: tuple, **kwargs: dict) -> Reply:
+        pass
+
+    @in_devmap
+    def task_start(self, key: tuple, task: Task, **kwargs) -> Reply:
+        """
+        Submit a :class:`Task` onto the specified device component.
+
+        Pushes the supplied :class:`Task` into the :class:`Queue` of the component,
+        then starts the worker thread. Checks that the :class:`Task` is among the
+        capabilities of this component.
+        """
+        logger.info("starting task '%s' on component %s", task.technique_name, key)
+        if task.technique_name not in self.devmap[key].capabilities(**kwargs):
+            return Reply(
+                success=False,
+                msg=f"unknown task {task.technique_name!r} requested",
+                data=self.capabilities(key=key),
+            )
+
+        self.devmap[key].task_list.put(task)
+        self.devmap[key].run()
+        logger.info("task '%s' on component %s started", task.technique_name, key)
+        return Reply(
+            success=True,
+            msg=f"task {task!r} started successfully",
+            data=task,
+        )
+
+    @in_devmap
+    def task_status(self, key: tuple, **kwargs: dict) -> Reply:
+        """
+        Returns the task readiness status of the specified device component.
+
+        The `running` entry in the data slot of the :class:`Reply` indicates whether
+        a :class:`Task` is running. The `can_submit` entry indicates whether another
+        :class:`Task` can be queued onto the device component already.
+        """
+        running = self.devmap[key].running
+        data = dict(running=running, can_submit=not running)
+        if running:
+            return Reply(success=True, msg="running", data=data)
+        else:
+            return Reply(success=True, msg="ready", data=data)
+
+    @in_devmap
+    def task_stop(self, key: tuple, **kwargs) -> Reply:
+        """
+        Stops a running task and returns any collected data.
+
+        Pass-through to :func:`DriverManager.stop_task` and :func:`task_data`.
+        """
+        ret = self.devmap[key].stop_task(**kwargs)
+        if ret is not None:
+            return Reply(success=False, msg="failed to stop task", data=ret)
+
+        ret = self.task_data(self, key=key)
+        if ret.success:
+            return Reply(success=True, msg=f"task stopped, {ret.msg}", data=ret.data)
+        else:
+            return Reply(success=True, msg=f"task stopped, {ret.msg}")
+
+    @in_devmap
+    def task_data(self, key: tuple, **kwargs) -> Reply:
+        """
+        Return cached task data on the device component and clean the cache.
+
+        Pass-through for :func:`DeviceManager.get_data`, with the caveat that the
+        :class:`dict[list]` which is returned from the component is here converted to a
+        :class:`Dataset` and annotated using units from :func:`attrs`.
+
+        This function gets called by the job thread every `device.pollrate`, it therefore
+        incurs some IPC cost.
+
+        """
+        data = self.devmap[key].get_data(**kwargs)
+
+        if len(data) == 0:
+            return Reply(success=False, msg="found no new datapoints")
+
+        attrs = self.devmap[key].attrs(**kwargs)
+        uts = {"uts": data.pop("uts")}
+        data_vars = {}
+        for k, v in data.items():
+            units = {} if attrs[k].units is None else {"units": attrs[k].units}
+            data_vars[k] = ("uts", v, units)
+        ds = Dataset(data_vars=data_vars, coords=uts)
+        return Reply(success=True, msg=f"found {len(data)} new datapoints", data=ds)
+
+    def status(self) -> Reply:
+        """
+        Returns the driver status. Currently that is the names of the components in
+        the `devmap`.
+
+        """
+        devkeys = self.devmap.keys()
+        return Reply(
+            success=True,
+            msg=f"driver running with {len(devkeys)} devices",
+            data=dict(devkeys=devkeys),
+        )
+
+    def reset(self) -> Reply:
+        """
+        Resets the driver.
+
+        Called when the driver process is quitting. Instructs all remaining tasks to
+        stop. Warns when devices linger. Passes through to :func:`dev_reset`. This is
+        not a pass-through to :func:`dev_teardown`.
+
+        """
+        logger.info("resetting all components on this driver")
+        for key, dev in self.devmap.items():
+            if dev.thread.is_alive():
+                logger.warning("stopping task on component %s", key)
+                setattr(dev.thread, "do_run", False)
+                dev.thread.join(timeout=1)
+            if dev.thread.is_alive():
+                logger.error("task on component %s is still running", key)
+            else:
+                logger.debug("component %s has no running task", key)
+            self.dev_reset(key=key)
+        return Reply(
+            success=True,
+            msg="all components on driver have been reset",
+        )
+
+
+class ModelDevice(metaclass=ABCMeta):
+    """
+    An abstract base class specifying a manager for an individual component.
+
+    This class should handle determining attributes and capabilities of the component,
+    the reading/writing of those attributes, processing of tasks, and caching and
+    returning of task data.
+    """
+
+    driver: "ModelInterface"
+    """The parent :class:`DriverInterface` instance."""
+
+    constants: dict[str, Any]
+    """Constant metadata of this component."""
+
+    data: dict[str, list]
+    """Container for cached data on this component."""
+
+    last_data: dict[str, Any]
+    """Container for last datapoint on this component."""
+
+    datalock: RLock
+    """Lock object for thread-safe data manipulation."""
+
+    key: tuple
+    """The key in :obj:`self.driver.devmap` referring to this object."""
+
+    thread: Thread
+    """The worker :class:`Thread`."""
+
+    task_list: Queue
+    """A :class:`Queue` used to pass :class:`Tasks` to the worker :class:`Thread`."""
+
+    running: bool
+
+    def __init__(self, driver, key, **kwargs):
+        self.driver = driver
+        self.key = key
+        self.task_list = Queue()
+        self.thread = Thread(target=self.task_runner, daemon=True)
+        self.data = defaultdict(list)
+        self.running = False
+        self.datalock = RLock()
+        self.constants = dict()
+        atexit.register(self.reset)
+
+    def run(self):
+        """Helper function for starting the :obj:`self.thread`."""
+        self.thread.do_run = True
+        self.thread.start()
+        self.running = True
+
+    def task_runner(self):
+        """
+        Target function for the :obj:`self.thread`.
+
+        This function waits for a :class:`Task` passed using :obj:`self.task_list`,
+        then handles setting all :class:`Attrs` using the :func:`prepare_task`
+        function, and finally handles the main loop of the task, periodically running
+        the :func:`do_task` function (using `task.sampling_interval`) until the
+        maximum task duration (i.e. `task.max_duration`) is exceeded.
+
+        The :obj:`self.thread` is re-primed for future :class:`Tasks` at the end
+        of this function.
+        """
+        thread = current_thread()
+        task: Task = self.task_list.get()
+        self.prepare_task(task)
+        t_start = time.perf_counter()
+        t_prev = t_start
+        self.data = defaultdict(list)
+        while getattr(thread, "do_run"):
+            t_now = time.perf_counter()
+            if t_now - t_prev > task.sampling_interval:
+                with self.datalock:
+                    self.do_task(task, t_start=t_start, t_now=t_now, t_prev=t_prev)
+                t_prev += task.sampling_interval
+            if t_now - t_start > task.max_duration:
+                break
+            time.sleep(max(1e-2, task.sampling_interval / 20))
+
+        self.task_list.task_done()
+        self.running = False
+        self.thread = Thread(target=self.task_runner, daemon=True)
+        logger.info("task '%s' on component %s is done", task.technique_name, self.key)
+
+    def prepare_task(self, task: Task, **kwargs: dict):
+        """
+        Given a :class:`Task`, prepare this component for execution by settin all
+        :class:`Attrs` as specified in the `task.technique_params` dictionary.
+        """
+        if task.technique_params is not None:
+            for k, v in task.technique_params.items():
+                self.set_attr(attr=k, val=v)
+
+    @abstractmethod
+    def do_task(self, task: Task, **kwargs: dict):
+        """
+        Periodically called task execution function.
+
+        This function is responsible for updating :obj:`self.data` with new data, i.e.
+        performing the measurement. It should also update the values of all
+        :class:`Attrs`, so that the component status is consistent with the cached data.
+        """
+        pass
+
+    def stop_task(self, **kwargs: dict):
+        """Stops the currently running task."""
+        logger.info("stopping running task on component %s", self.key)
+        setattr(self.thread, "do_run", False)
+
+    @abstractmethod
+    def set_attr(self, attr: str, val: Any, **kwargs: dict):
+        """Sets the specified :class:`Attr` to `val`."""
+        pass
+
+    @abstractmethod
+    def get_attr(self, attr: str, **kwargs: dict) -> Any:
+        """Reads the value of the specified :class:`Attr`."""
+        pass
+
+    def get_data(self, **kwargs: dict) -> dict[str, list]:
+        """Returns the cached :obj:`self.data` before clearing the cache."""
+        with self.datalock:
+            ret = self.data
+            self.data = defaultdict(list)
+        return ret
+
+    def get_last_data(self, **kwargs: dict) -> dict[str, list]:
+        """Returns the :obj:`last_data` object as a dict."""
+        return self.last_data
+
+    @abstractmethod
+    def attrs(**kwargs) -> dict[str, Attr]:
+        """Returns a :class:`dict` of all available :class:`Attrs`."""
+        pass
+
+    @abstractmethod
+    def capabilities(**kwargs) -> set:
+        """Returns a :class:`set` of all supported techniques."""
+        pass
+
+    def status(self, **kwargs) -> dict:
+        """Compiles a status report from :class:`Attrs` marked as `status=True`."""
+        status = {}
+        for attr, props in self.attrs().items():
+            if props.status:
+                status[attr] = self.get_attr(attr)
+        return status
+
+    def reset(self, **kwargs) -> None:
+        """Resets the component to an initial status."""
+        logger.info("resetting component %s", self.key)
+        self.task_list = Queue()
+        self.thread = Thread(target=self.task_runner, daemon=True)
+        self.data = defaultdict(list)
+        self.running = False
+        self.datalock = RLock()

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -74,6 +74,7 @@ class ModelInterface(metaclass=ABCMeta):
 
     def __init__(self, settings=None):
         self.devmap = {}
+        self.constants = {}
         self.settings = settings if settings is not None else {}
 
     def dev_register(self, address: str, channel: str, **kwargs: dict) -> Reply:
@@ -214,7 +215,11 @@ class ModelInterface(metaclass=ABCMeta):
         """
         Query constants on the specified device component and this driver.
         """
+        logger.critical(f"In func")
+        logger.critical(f"{self.constants}")
+        logger.critical(f"{self.devmap[key].constants}")
         ret = self.constants | self.devmap[key].constants
+        logger.critical(f"{ret=}")
         return Reply(
             success=True,
             msg=f"constants of component {key!r} are: {ret}",

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -210,6 +210,18 @@ class ModelInterface(metaclass=ABCMeta):
         )
 
     @in_devmap
+    def dev_constants(self, key: tuple, **kwargs: dict) -> Reply:
+        """
+        Query constants on the specified device component and this driver.
+        """
+        ret = self.constants | self.devmap[key].constants
+        return Reply(
+            success=True,
+            msg=f"constants of component {key!r} are: {ret}",
+            data=ret,
+        )
+
+    @in_devmap
     def dev_get_data(self, key: tuple, **kwargs: dict) -> Reply:
         pass
 

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -215,11 +215,7 @@ class ModelInterface(metaclass=ABCMeta):
         """
         Query constants on the specified device component and this driver.
         """
-        logger.critical(f"In func")
-        logger.critical(f"{self.constants}")
-        logger.critical(f"{self.devmap[key].constants}")
         ret = self.constants | self.devmap[key].constants
-        logger.critical(f"{ret=}")
         return Reply(
             success=True,
             msg=f"constants of component {key!r} are: {ret}",

--- a/src/tomato/models.py
+++ b/src/tomato/models.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 class Driver(BaseModel):
     name: str
+    version: Optional[str] = None
     port: Optional[int] = None
     pid: Optional[int] = None
     spawned_at: Optional[str] = None

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -64,7 +64,10 @@ def attrs(
     kwargs = dict(channel=cmp.channel, address=cmp.address)
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{drv.port}")
-    req.send_pyobj(dict(cmd="dev_attrs", params={**kwargs}))
+    if drv.version == "1.0":
+        req.send_pyobj(dict(cmd="attrs", params={**kwargs}))
+    else:
+        req.send_pyobj(dict(cmd="dev_attrs", params={**kwargs}))
     ret = req.recv_pyobj()
     return ret
 
@@ -85,7 +88,10 @@ def capabilities(
     kwargs = dict(channel=cmp.channel, address=cmp.address)
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{drv.port}")
-    req.send_pyobj(dict(cmd="dev_capabilities", params={**kwargs}))
+    if drv.version == "1.0":
+        req.send_pyobj(dict(cmd="capabilities", params={**kwargs}))
+    else:
+        req.send_pyobj(dict(cmd="dev_capabilities", params={**kwargs}))
     ret = req.recv_pyobj()
     return ret
 
@@ -106,6 +112,12 @@ def constants(
     kwargs = dict(channel=cmp.channel, address=cmp.address)
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{drv.port}")
+    if drv.version == "1.0":
+        return Reply(
+            success=False,
+            msg=f"driver of component {name!r} is on version {drv.version}",
+            data=None,
+        )
     req.send_pyobj(dict(cmd="dev_constants", params={**kwargs}))
     ret = req.recv_pyobj()
     return ret

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -64,7 +64,7 @@ def attrs(
     kwargs = dict(channel=cmp.channel, address=cmp.address)
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{drv.port}")
-    req.send_pyobj(dict(cmd="attrs", params={**kwargs}))
+    req.send_pyobj(dict(cmd="dev_attrs", params={**kwargs}))
     ret = req.recv_pyobj()
     return ret
 
@@ -85,7 +85,28 @@ def capabilities(
     kwargs = dict(channel=cmp.channel, address=cmp.address)
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{drv.port}")
-    req.send_pyobj(dict(cmd="capabilities", params={**kwargs}))
+    req.send_pyobj(dict(cmd="dev_capabilities", params={**kwargs}))
+    ret = req.recv_pyobj()
+    return ret
+
+
+def constants(
+    *,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
+        return ret
+    cmp, drv = ret
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
+    req.send_pyobj(dict(cmd="dev_constants", params={**kwargs}))
     ret = req.recv_pyobj()
     return ret
 

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -173,7 +173,7 @@ def _status_helper(daemon: Daemon, yaml: bool, stgrp: str):
         else:
             ii = []
             for i in daemon.drvs.values():
-                line = f"name:{i.name}\tport:{i.port}\tpid:{i.pid}"
+                line = f"name:{i.name}\tport:{i.port}\tpid:{i.pid}\tversion:{i.version}"
                 ii.append(line)
             if len(ii) == 0:
                 msg = f"tomato running on port {daemon.port} with no drivers"

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -89,6 +89,17 @@ def test_passata_api_reset(start_tomato_daemon, stop_tomato_daemon):
     assert ret.success
 
 
+def test_passata_api_constants(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = tomato.passata.constants(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    print(f"{ret=}")
+    assert ret.success
+    assert ret.data["example_meta"] == "example string"
+
+
 def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=3000)
     ret = subprocess.run(
@@ -153,3 +164,18 @@ def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):
         "Success: attr 'max' of component 'example_counter:(example-addr,1)' is"
         in ret.stdout
     )
+
+    ret = subprocess.run(
+        [
+            "passata",
+            "constants",
+            "example_counter:(example-addr,1)",
+            "max",
+            "-p",
+            f"{PORT}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    print(f"{ret=}")
+    assert "Success: constants of component ('example-addr', '1') are" in ret.stdout

--- a/tests/test_99_psutil.py
+++ b/tests/test_99_psutil.py
@@ -56,6 +56,7 @@ def test_psutil_passata(datadir, stop_tomato_daemon):
     subprocess.run(["tomato", "init", "-p", f"{PORT}", "-A", ".", "-D", ".", "-L", "."])
     subprocess.run(["tomato", "start", "-p", f"{PORT}", "-A", ".", "-vv"])
     utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
 
     ret = tomato.status(port=PORT, timeout=1000, context=CTXT, stgrp="drivers")
     assert ret.success

--- a/tests/test_99_psutil.py
+++ b/tests/test_99_psutil.py
@@ -84,6 +84,6 @@ def test_psutil_passata(datadir, stop_tomato_daemon):
     )
     print(f"{ret=}")
     assert (
-        "Failure: driver of component ('psutil-addr', '10') is on version 1.0"
+        "Failure: driver of component 'psutil:(psutil-addr,10)' is on version 1.0"
         in ret.stdout
     )

--- a/tests/test_99_psutil.py
+++ b/tests/test_99_psutil.py
@@ -4,10 +4,14 @@ import subprocess
 import json
 import yaml
 import xarray as xr
+import zmq
+from tomato import tomato
+
 
 from . import utils
 
 PORT = 12345
+CTXT = zmq.Context()
 
 
 @pytest.mark.parametrize(
@@ -41,3 +45,45 @@ def test_psutil_multidev(casename, npoints, datadir, stop_tomato_daemon):
     for group, points in npoints.items():
         print(f"{dt[group]=}")
         assert dt[group]["uts"].size == points
+
+
+def test_psutil_passata(datadir, stop_tomato_daemon):
+    os.chdir(datadir)
+    with open("devices_psutil.json", "r") as inf:
+        jsdata = json.load(inf)
+    with open("devices.yml", "w") as ouf:
+        yaml.dump(jsdata, ouf)
+    subprocess.run(["tomato", "init", "-p", f"{PORT}", "-A", ".", "-D", ".", "-L", "."])
+    subprocess.run(["tomato", "start", "-p", f"{PORT}", "-A", ".", "-vv"])
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+
+    ret = tomato.status(port=PORT, timeout=1000, context=CTXT, stgrp="drivers")
+    assert ret.success
+    assert ret.data["psutil"].version == "1.0"
+
+    ret = subprocess.run(
+        ["passata", "status", "psutil:(psutil-addr,10)", "-p", f"{PORT}"],
+        capture_output=True,
+        text=True,
+    )
+    print(f"{ret=}")
+    assert "Success: component ('psutil-addr', '10') is not running" in ret.stdout
+
+    ret = subprocess.run(
+        ["passata", "attrs", "psutil:(psutil-addr,10)", "-p", f"{PORT}"],
+        capture_output=True,
+        text=True,
+    )
+    print(f"{ret=}")
+    assert "Success: attrs of component ('psutil-addr', '10') are" in ret.stdout
+
+    ret = subprocess.run(
+        ["passata", "constants", "psutil:(psutil-addr,10)", "-p", f"{PORT}"],
+        capture_output=True,
+        text=True,
+    )
+    print(f"{ret=}")
+    assert (
+        "Failure: driver of component ('psutil-addr', '10') is on version 1.0"
+        in ret.stdout
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import time
 import logging
 import os
 import psutil
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,24 @@ def wait_until_tomato_running(port: int, timeout: int):
             text=True,
         )
         if "Success" in ret.stdout:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def wait_until_tomato_drivers(port: int, timeout: int):
+    t0 = time.perf_counter()
+    while (time.perf_counter() - t0) < (timeout / 1000):
+        ret = subprocess.run(
+            ["tomato", "status", "drivers", "-y", "-p", f"{port}"],
+            capture_output=True,
+            text=True,
+        )
+        yml = yaml.safe_load(ret.stdout)
+        for name, drv in yml["data"].items():
+            if drv["port"] is None:
+                break
+        else:
             return True
         time.sleep(0.5)
     return False


### PR DESCRIPTION
Closes #120.

Also adds `version` to `tomato.models.Driver`, so that `passata` (and other utils) can infer what API they need to target.