### PR TITLE
`DriverModel-2.0`: Timestamping of `last_data`.

### DIFF
--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -15,7 +15,10 @@ Changes from ``tomato-1.0`` include:
 - The ``tomato status`` command now supports further arguments: ``pipelines``, ``drivers``, ``devices``, and ``components`` can be used to query status of subsets of the running **tomato**.
 - A new ``passata`` command and :mod:`tomato.passata` module for interacting with *components* over CLI and API.
 - A new ``DriverInterface-2.0``, with the following changes:
-  - ``constants``: a container for constant *driver* and *component*-specific metadata
+  - :func:`dev_constants`: an accessor for :obj:`ModelDevice.constants` and :obj:`ModelInterface.constants`, which are containers for the *driver* and *component*-specific metadata,
+  - :func:`dev_last_data`: an accessor for :obj:`ModelDevice.last_data`, which should contain the last timestamped datapoint,
+  - :func:`dev_measure`: a passthrough function to launch :func:`ModelDevice.measure`, which will trigger a one-shot measurement to populate :obj:`ModelDevice.last_data`
+  - :func:`DeviceFactory`: a factory function that creates an appropriate :obj:`ModelDevice` instance.
 
 .. codeauthor::
     Peter Kraus

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -7,7 +7,7 @@ from tomato.models import Reply
 from dgbowl_schemas.tomato.payload import Task
 import logging
 from functools import wraps
-from xarray import Dataset, DataArray
+from xarray import Dataset
 import time
 import atexit
 
@@ -240,7 +240,7 @@ class ModelInterface(metaclass=ABCMeta):
 
     @in_devmap
     def dev_measure(self, key: tuple, **kwargs: dict) -> Reply:
-        ret = self.devmap[key].measure()
+        self.devmap[key].measure()
         return Reply(
             success=True,
             msg=f"measurement started on component {key!r}",
@@ -461,9 +461,7 @@ class ModelDevice(metaclass=ABCMeta):
         self.do_measure()
         self.running = False
         self.thread = Thread(target=self.task_runner, daemon=True)
-        logger.info(
-            "measurement on component %s is done", task.technique_name, self.key
-        )
+        logger.info("measurement on component %s is done", self.key)
 
     def prepare_task(self, task: Task, **kwargs: dict):
         """

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -109,15 +109,16 @@ def constants(
         return ret
     cmp, drv = ret
 
-    kwargs = dict(channel=cmp.channel, address=cmp.address)
-    req = context.socket(zmq.REQ)
-    req.connect(f"tcp://127.0.0.1:{drv.port}")
     if drv.version == "1.0":
         return Reply(
             success=False,
             msg=f"driver of component {name!r} is on version {drv.version}",
             data=None,
         )
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
     req.send_pyobj(dict(cmd="dev_constants", params={**kwargs}))
     ret = req.recv_pyobj()
     return ret
@@ -201,5 +202,61 @@ def reset(
     req = context.socket(zmq.REQ)
     req.connect(f"tcp://127.0.0.1:{drv.port}")
     req.send_pyobj(dict(cmd="dev_reset", params=kwargs))
+    ret = req.recv_pyobj()
+    return ret
+
+
+def get_last_data(
+    *,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
+        return ret
+    cmp, drv = ret
+
+    if drv.version == "1.0":
+        return Reply(
+            success=False,
+            msg=f"driver of component {name!r} is on version {drv.version}",
+            data=None,
+        )
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
+    req.send_pyobj(dict(cmd="dev_last_data", params=kwargs))
+    ret = req.recv_pyobj()
+    return ret
+
+
+def measure(
+    *,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
+        return ret
+    cmp, drv = ret
+
+    if drv.version == "1.0":
+        return Reply(
+            success=False,
+            msg=f"driver of component {name!r} is on version {drv.version}",
+            data=None,
+        )
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
+    req.send_pyobj(dict(cmd="dev_measure", params=kwargs))
     ret = req.recv_pyobj()
     return ret

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -100,6 +100,33 @@ def test_passata_api_constants(start_tomato_daemon, stop_tomato_daemon):
     assert ret.data["example_meta"] == "example string"
 
 
+def test_passata_api_last_data_none(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = tomato.passata.get_last_data(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    print(f"{ret=}")
+    assert not ret.success
+
+
+def test_passata_api_measure_last_data(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    ret = tomato.passata.measure(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    assert ret.success
+
+    ret = tomato.passata.get_last_data(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    print(f"{ret=}")
+    assert ret.success
+    assert "uts" in ret.data.coords
+
+
 def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=3000)
     ret = subprocess.run(

--- a/tests/test_99_example_counter.py
+++ b/tests/test_99_example_counter.py
@@ -144,7 +144,6 @@ def test_counter_measure_task_measure(datadir, start_tomato_daemon, stop_tomato_
 
     utils.run_casenames(["counter_5_0.2"], [None], ["pip-counter"])
     utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
-    status = utils.job_status(1)
     ret = tomato.passata.measure(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -153,7 +152,6 @@ def test_counter_measure_task_measure(datadir, start_tomato_daemon, stop_tomato_
     assert "measurement already running" in ret.msg
 
     utils.wait_until_ketchup_status(jobid=1, status="c", port=PORT, timeout=5000)
-    status = utils.job_status(1)
     ret = tomato.passata.measure(
         name="example_counter:(example-addr,1)",
         **kwargs,

--- a/tests/test_99_example_counter.py
+++ b/tests/test_99_example_counter.py
@@ -159,4 +159,3 @@ def test_counter_measure_task_measure(datadir, start_tomato_daemon, stop_tomato_
         **kwargs,
     )
     assert ret.success
-

--- a/tests/test_99_example_counter.py
+++ b/tests/test_99_example_counter.py
@@ -5,10 +5,13 @@ import time
 import json
 import yaml
 import xarray as xr
+import tomato
+import zmq
 
 from . import utils
 
 PORT = 12345
+CTXT = zmq.Context()
 
 
 @pytest.mark.parametrize(
@@ -127,3 +130,33 @@ def test_counter_multidev(casename, npoints, datadir, stop_tomato_daemon):
     for group, points in npoints.items():
         print(f"{dt[group]=}")
         assert dt[group]["uts"].size == points
+
+
+def test_counter_measure_task_measure(datadir, start_tomato_daemon, stop_tomato_daemon):
+    os.chdir(datadir)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
+    kwargs = dict(port=PORT, timeout=1000, context=CTXT)
+    ret = tomato.passata.measure(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    assert ret.success
+
+    utils.run_casenames(["counter_5_0.2"], [None], ["pip-counter"])
+    utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
+    status = utils.job_status(1)
+    ret = tomato.passata.measure(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    assert not ret.success
+    assert "measurement already running" in ret.msg
+
+    utils.wait_until_ketchup_status(jobid=1, status="c", port=PORT, timeout=5000)
+    status = utils.job_status(1)
+    ret = tomato.passata.measure(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    assert ret.success
+


### PR DESCRIPTION
Closes #122.
Closes #97.

This PR ensures the `last_data` has timestamps. It also adds an abstract method `ModelDevice.do_measure()`, which should perform an one-shot measurement and update the `last_data` object. The method is accessible via: 
```
passata.measure() -> ModelInterface.dev_measure() -> ModelDevice.measure() -> new thread
       Thread -> ModelDevice.meas_runner() -> ModelDevice.do_measure()
```

To do:
- [x] documentation
- [x] make sure `task_runner` and `meas_runner` cannot be invoked at the same time (e.g. via `running` flag)