### PR TITLE
Unit-aware attributes.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,6 +81,7 @@ autosummary_generate = True
 autodoc_default_flags = ["members", "undoc-members", "show-inheritance"]
 autodoc_member_order = "bysource"
 autodoc_pydantic_model_show_field_summary = False
+autodoc_pydantic_model_show_json_error_strategy = "coerce"
 # autodoc_pydantic_model_show_validator_summary = False
 autodoc_pydantic_model_member_order = "bysource"
 intersphinx_mapping = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "h5netcdf >= 1.3",
     "xarray >= 2024.10.0",
     "pydantic >= 2.0",
+    "pint >= 0.24.1",
 ]
 
 [project.optional-dependencies]

--- a/src/tomato/driverinterface_1_0/__init__.py
+++ b/src/tomato/driverinterface_1_0/__init__.py
@@ -1,3 +1,18 @@
+"""
+**DriverInterface-1.0**
+-----------------------
+.. codeauthor::
+    Peter Kraus
+
+... warning:
+
+    This version of DriverInterface is deprecated and will not be supported from ``tomato-3.0`` onwards.
+
+
+First prototype of the DriverInterface.
+
+"""
+
 from abc import ABCMeta, abstractmethod
 from typing import TypeVar, Any
 from pydantic import BaseModel

--- a/src/tomato/driverinterface_1_0/__init__.py
+++ b/src/tomato/driverinterface_1_0/__init__.py
@@ -4,7 +4,7 @@
 .. codeauthor::
     Peter Kraus
 
-... warning:
+.. warning::
 
     This version of DriverInterface is deprecated and will not be supported from ``tomato-3.0`` onwards.
 

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -191,6 +191,7 @@ class ModelInterface(metaclass=ABCMeta):
         ret = self.devmap[key].set_attr(attr=attr, val=val, **kwargs)
         return (True, f"attr {attr!r} of component {key} set to {ret}", ret)
 
+    @to_reply
     @in_devmap
     def dev_get_attr(
         self, attr: str, key: Key, **kwargs: dict

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -8,8 +8,8 @@
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import TypeVar, Any, Union, TypeAlias
-from pydantic import BaseModel
+from typing import TypeVar, Any, Union, TypeAlias, Optional
+from pydantic import BaseModel, Field
 from threading import Thread, current_thread, RLock
 from queue import Queue
 from tomato.models import Reply
@@ -63,7 +63,7 @@ def to_reply(func):
     return wrapper
 
 
-class Attr(BaseModel):
+class Attr(BaseModel, arbitrary_types_allowed=True):
     """A Pydantic :class:`BaseModel` used to describe device attributes."""
 
     type: Type
@@ -78,10 +78,10 @@ class Attr(BaseModel):
     units: str = None
     """Default units for the attribute, optional."""
 
-    maximum: Union[pint.Quantity, float] = None
+    maximum: Optional[float | pint.Quantity] = Field(None, union_mode="left_to_right")
     """Maximum value for the attribute, optional."""
 
-    minimum: Union[pint.Quantity, float] = None
+    minimum: Optional[float | pint.Quantity] = Field(None, union_mode="left_to_right")
     """Minimum value for the attribute, optional."""
 
 

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -74,7 +74,7 @@ class Attr(BaseModel):
 
     status: bool = False
     """Should the attribute be included in component status?"""
-    
+
     units: str = None
     """Default units for the attribute, optional."""
 
@@ -120,7 +120,7 @@ class ModelInterface(metaclass=ABCMeta):
         self.settings = settings if settings is not None else {}
 
     @abstractmethod
-    def DeviceFactory(self, key: Key, **kwargs) -> ModelInterface:
+    def DeviceFactory(self, key: Key, **kwargs) -> "ModelDevice":
         """
         A factory function which is used to pass this instance of the :class:`ModelInterface`
         to the new :class:`ModelDevice` instance.

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -307,7 +307,7 @@ class ModelInterface(metaclass=ABCMeta):
         logger.info("starting task '%s' on component %s", task.technique_name, key)
         if task.technique_name not in self.devmap[key].capabilities(**kwargs):
             msg = f"unknown task {task.technique_name!r} requested"
-            return (False, msg, self.capabilities(key=key))
+            return (False, msg, self.dev_capabilities(key=key))
         else:
             self.devmap[key].task_list.put(task)
             self.devmap[key].run()

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -12,7 +12,8 @@ kwargs = dict(port=PORT, timeout=TIME, context=CTXT)
 
 
 def test_passata_api_status(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = tomato.passata.status(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -23,7 +24,8 @@ def test_passata_api_status(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_attrs(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = tomato.passata.attrs(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -34,7 +36,8 @@ def test_passata_api_attrs(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_capabs(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = tomato.passata.capabilities(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -45,7 +48,8 @@ def test_passata_api_capabs(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_get_attrs(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = tomato.passata.get_attrs(
         name="example_counter:(example-addr,1)",
         attrs=["max", "min"],
@@ -58,7 +62,8 @@ def test_passata_api_get_attrs(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_set_attr(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     val = random.random() * 100
     ret = tomato.passata.set_attr(
         name="example_counter:(example-addr,1)",
@@ -80,7 +85,8 @@ def test_passata_api_set_attr(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_reset(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = tomato.passata.reset(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -90,7 +96,8 @@ def test_passata_api_reset(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_constants(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = tomato.passata.constants(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -101,7 +108,8 @@ def test_passata_api_constants(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_last_data_none(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = tomato.passata.get_last_data(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -111,7 +119,8 @@ def test_passata_api_last_data_none(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_measure_last_data(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = tomato.passata.measure(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -128,7 +137,8 @@ def test_passata_api_measure_last_data(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     ret = subprocess.run(
         [
             "passata",


### PR DESCRIPTION
Closes #118 by explicitly pushing unit and type validation to individual drivers.

A new type alias, `Val = TypeVar("Val", str, int, float, pint.Quantity)` is introduced, which should make handling the values of `Attrs` more transparent.