### PR TITLE
Idle measurement interval

### DIFF
--- a/docs/source/driver_develop.rst
+++ b/docs/source/driver_develop.rst
@@ -10,11 +10,18 @@ Since ``tomato-1.0``, all device *drivers* are developed as separate Python pack
 
 Bootstrapping a *driver* process
 ````````````````````````````````
-When the *driver* process is launched (as a ``tomato-driver``), it's given information about how to connect to the ``tomato-daemon`` process and which device *driver* to spawn. Once a connection to the ``tomato-daemon`` is established, the *driver* settings are fetched, and the :class:`DriverInterface` is instantiated passing any settings to the constructor. Then, all *components* on all *devices* of this *driver* type that are known to ``tomato-daemon`` are registered using the :func:`cmp_register` function.
+When the *driver* process is launched (as a ``tomato-driver``), it's given information about how to connect to the ``tomato-daemon`` process and which device *driver* to spawn. Once a connection to the ``tomato-daemon`` is established, the *driver* settings (from the :ref:`*settings file* <setfile>`) are fetched, and the :class:`DriverInterface` is instantiated passing any settings to the constructor. By default, these settings are stored under :obj:`DriverInterface.settings`. Finally, all *components* on all *devices* of this *driver* type that are known to ``tomato-daemon`` are registered using the :func:`cmp_register` function.
 
 .. note::
 
     Each *driver* creates a separate log file for each port **tomato** has been executed with. The logfile is stored in the same location as the ``tomato-daemon`` logs, i.e. as configured under the ``logdir`` option in the *settings file*. The verbosity of the ``tomato-driver`` process is inherited from the ``tomato-daemon`` process.
+
+*Driver*-specific settings
+``````````````````````````
+The following keywords in the driver-specific settings in the :ref:`*settings file* <setfile>` are reserved for use by **tomato**:
+
+- ``idle_measurement_interval``: Specifies the interval (in seconds) after which the :func:`do_measure` function of all *components* registered on the *driver* should be called. The :func:`do_measure` is only called for *components* that are idle, i.e. without a running :class:`Task`. Overrides any :obj:`DriverInterface.idle_measurement_interval`.
+
 
 Communication between *jobs* and *drivers*
 ``````````````````````````````````````````

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -162,7 +162,7 @@ The *settings file* contains the basic information required to start the ``tomat
     config = '/home/kraus/.config/tomato/1.0a1/devices.yml'
 
     [drivers]
-    example_counter.testpar = 1234
+    example_counter.idle_measurement_interval = 1
 
 
 In addition to the *appdir*, a second path, *datadir*, is used to specify the location of the data created by **tomato**. The default *datadir* is:
@@ -181,7 +181,7 @@ In the default *settings file* shown above, the following entries are specified:
 - ``jobs.dbpath`` which is the location of the ``sqlite3`` database used to track *jobs*, 
 - ``devices.config`` which points to a ``yaml``-formatted :ref:`devices file <devfile>`, defining the hardware configuration of the devices managed by **tomato**.
 
-Additional, *driver*-specific settings may be provided in the ``[drivers]`` section, following the example of the ``drivers.example_counter.testpar`` entry. These *driver*-specific settings are passed to each *driver* when its process is launched and the :class:`DriverInterface` is initialised, and can therefore contain paths to various libraries or other files necessary for the *driver* to function.
+Additional, *driver*-specific settings may be provided in the ``[drivers]`` section, following the example of the ``drivers.example_counter.idle_measurement_interval`` entry. These *driver*-specific settings are passed to each *driver* when its process is launched and the :class:`DriverInterface` is initialised, and can therefore contain paths to various libraries or other files necessary for the *driver* to function.
 
 .. _devfile:
 

--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -1,5 +1,21 @@
 Version history
 ===============
+**tomato**-next
+---------------
+
+.. sectionauthor::
+     Peter Kraus
+
+Developed at the ConCat lab at TU Berlin.
+
+Changes from ``tomato-2.0`` include:
+
+- *Driver* processess are now better at logging errors. All ``Exceptions`` raised by the :obj:`DriverInterface` should should now be caught and logged; as functionality of the *components* should only be accessed via the :obj:`DriverInterface`, this should catch all cases. 
+- The :func:`do_measure` of each *component* can now be periodically called by the *driver* process, if a task is not running. The interval (in seconds) can be configured by the user in the *driver* section of the :ref:`*settings file* <setfile>` (under ``driver.<driver_name>.idle_measurement_interval``) or provided by the driver developer (under :obj:`DriverInterface.idle_measurement_interval`); it falls back to ``None`` which means no periodic measurement will be done.
+
+.. codeauthor::
+    Peter Kraus
+
 **tomato**-v2.0
 ---------------
 .. image:: https://img.shields.io/static/v1?label=tomato&message=v2.0&color=blue&logo=github

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -59,10 +59,15 @@ def tomato_driver_bootstrap(
 def perform_idle_measurements(
     interface: ModelInterface, t_last: Union[float, None]
 ) -> Union[float, None]:
-    imi = interface.settings.get("idle_measurement_interval", IDLE_MEASUREMENT_INTERVAL)
+    if "idle_measurement_interval" in interface.settings:
+        imi = interface.settings["idle_measurement_interval"]
+    elif hasattr(inteface, "IDLE_MEASUREMENT_INTERVAL"):
+        imi = inteface.IDLE_MEASUREMENT_INTERVAL
+    else:
+        imi = IDLE_MEASUREMENT_INTERVAL
     t_now = time.perf_counter()
     if imi is None:
-        return t_last
+        return None
     if t_last is not None and t_now - t_last < imi:
         return t_last
     for cname, cmp in interface.devmap.items():

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -61,8 +61,8 @@ def perform_idle_measurements(
 ) -> Union[float, None]:
     if "idle_measurement_interval" in interface.settings:
         imi = interface.settings["idle_measurement_interval"]
-    elif hasattr(inteface, "IDLE_MEASUREMENT_INTERVAL"):
-        imi = inteface.IDLE_MEASUREMENT_INTERVAL
+    elif hasattr(interface, "idle_measurement_interval"):
+        imi = interface.idle_measurement_interval
     else:
         imi = IDLE_MEASUREMENT_INTERVAL
     t_now = time.perf_counter()

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -23,10 +23,11 @@ import psutil
 from tomato.driverinterface_1_0 import ModelInterface as MI_1_0
 from tomato.driverinterface_2_0 import ModelInterface as MI_2_0
 from tomato.drivers import driver_to_interface
-from tomato.models import Reply
+from tomato.models import Reply, Daemon
 
 logger = logging.getLogger(__name__)
 ModelInterface = Union[MI_1_0, MI_2_0]
+IDLE_MEASUREMENT_INTERVAL = None
 
 
 def tomato_driver_bootstrap(
@@ -34,21 +35,41 @@ def tomato_driver_bootstrap(
 ):
     logger.debug("getting daemon status")
     req.send_pyobj(dict(cmd="status"))
-    daemon = req.recv_pyobj().data
+    daemon: Daemon = req.recv_pyobj().data
     drv = daemon.drvs[driver]
     interface.settings = drv.settings
 
     logger.info("registering components for driver '%s'", driver)
     for comp in daemon.cmps.values():
         if comp.driver == driver:
-            logger.info("registering component %s", (comp.address, comp.channel))
-            logger.critical(f"{interface=}")
+            logger.info("registering component %s", comp.name)
             ret = interface.dev_register(address=comp.address, channel=comp.channel)
-            logger.critical(f"{ret=}")
+            if ret.success:
+                logger.debug("registered component %s: %s", comp.name, ret.msg)
+            else:
+                logger.critical(
+                    "failed to register component %s: %s", comp.name, ret.msg
+                )
             params = dict(name=comp.name, capabilities=ret.data)
             req.send_pyobj(dict(cmd="component", params=params))
             ret = req.recv_pyobj()
     logger.info("driver '%s' bootstrapped successfully", driver)
+
+
+def perform_idle_measurements(
+    interface: ModelInterface, t_last: Union[float, None]
+) -> Union[float, None]:
+    imi = interface.settings.get("idle_measurement_interval", IDLE_MEASUREMENT_INTERVAL)
+    t_now = time.perf_counter()
+    if imi is None:
+        return t_last
+    if t_last is not None and t_now - t_last < imi:
+        return t_last
+    for cname, cmp in interface.devmap.items():
+        if cmp.running is False and hasattr(cmp, "do_measure"):
+            logger.debug("running measurement on component %s", cname)
+            cmp.do_measure()
+    return t_now
 
 
 def tomato_driver() -> None:
@@ -153,6 +174,7 @@ def tomato_driver() -> None:
     poller = zmq.Poller()
     poller.register(rep, zmq.POLLIN)
     status = "running"
+    t_last = None
     while True:
         socks = dict(poller.poll(100))
         if rep in socks:
@@ -197,6 +219,8 @@ def tomato_driver() -> None:
             rep.send_pyobj(ret)
         if status == "stop":
             break
+        elif status == "running":
+            t_last = perform_idle_measurements(interface, t_last)
 
     logger.info("driver '%s' is beginning reset", args.driver)
     interface.reset()

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -32,7 +32,7 @@ Key: TypeAlias = tuple[str, str]
 
 def in_devmap(func):
     """
-    Helper decorator for coercing ``(address, channel)`` into ``key`` 
+    Helper decorator for coercing ``(address, channel)`` into ``key``
     and checking that it is in :obj:`self.devmap`.
     """
 
@@ -129,13 +129,18 @@ class ModelInterface(metaclass=ABCMeta):
 
     """
 
+    # Class attributes
     version: str = "2.0"
 
+    idle_measurement_interval: Union[int, None] = None
+    """The interval (in seconds) after which :func:`self.do_measure` will be executed, when idle."""
+
+    # Instance attributes
     devmap: dict[tuple, "ModelDevice"]
     """Map of registered devices, the tuple keys are `component = (address, channel)`"""
 
     settings: dict[str, Any]
-    """A settings map to contain driver-specific settings such as `dllpath` for BioLogic"""
+    """A settings map to contain driver-specific settings such as ``dllpath`` for BioLogic"""
 
     constants: dict[str, Any]
     """A map that should be populated with driver-specific run-time constants."""

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -31,6 +31,11 @@ Key: TypeAlias = tuple[str, str]
 
 
 def in_devmap(func):
+    """
+    Helper decorator for coercing ``(address, channel)`` into ``key`` 
+    and checking that it is in :obj:`self.devmap`.
+    """
+
     @wraps(func)
     def wrapper(self, **kwargs):
         if "key" in kwargs:

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -468,7 +468,7 @@ def init(
         config = '{appdir / "devices.yml"}'
 
         [drivers]
-        example_counter.testpar = 1234
+        example_counter.idle_measurement_interval = 1
         """
     )
     if not appdir.exists():

--- a/tests/test_04_tomato_reload.py
+++ b/tests/test_04_tomato_reload.py
@@ -34,7 +34,7 @@ def test_reload_settings(datadir, start_tomato_daemon, stop_tomato_daemon):
     assert len(ret.data.devs) == 1
     assert len(ret.data.pips) == 1
     assert len(ret.data.cmps) == 1
-    assert ret.data.drvs["example_counter"].settings == {"testpar": 1234, "testparb": 1}
+    assert ret.data.drvs["example_counter"].settings["testparb"] == 1
 
 
 def test_reload_cmps_pips(datadir, start_tomato_daemon, stop_tomato_daemon):

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -107,26 +107,9 @@ def test_passata_api_constants(start_tomato_daemon, stop_tomato_daemon):
     assert ret.data["example_meta"] == "example string"
 
 
-def test_passata_api_last_data_none(start_tomato_daemon, stop_tomato_daemon):
+def test_passata_api_last_data(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=1000)
     utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    ret = tomato.passata.get_last_data(
-        name="example_counter:(example-addr,1)",
-        **kwargs,
-    )
-    print(f"{ret=}")
-    assert not ret.success
-
-
-def test_passata_api_measure_last_data(start_tomato_daemon, stop_tomato_daemon):
-    utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    ret = tomato.passata.measure(
-        name="example_counter:(example-addr,1)",
-        **kwargs,
-    )
-    assert ret.success
-
     ret = tomato.passata.get_last_data(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -134,6 +117,16 @@ def test_passata_api_measure_last_data(start_tomato_daemon, stop_tomato_daemon):
     print(f"{ret=}")
     assert ret.success
     assert "uts" in ret.data.coords
+
+
+def test_passata_api_measure(start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
+    ret = tomato.passata.measure(
+        name="example_counter:(example-addr,1)",
+        **kwargs,
+    )
+    assert ret.success
 
 
 def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):


### PR DESCRIPTION
Implements support for `DriverInterface.idle_measurement_interval` as well as the corresponding entry in the settings file.

By setting this interval, the `do_measure()` of each component the driver is aware of will be periodically executed, unless a `Task` is already running on the component. This means e.g. `marinara` doesn't need to trigger measurements periodically. Defaults to `None` (i.e. no idle measurements).