### PR TITLE
Use `cmp_measure` instead of `do_measure`

### DIFF
--- a/docs/source/driver_develop.rst
+++ b/docs/source/driver_develop.rst
@@ -20,7 +20,7 @@ When the *driver* process is launched (as a ``tomato-driver``), it's given infor
 ``````````````````````````
 The following keywords in the driver-specific settings in the :ref:`*settings file* <setfile>` are reserved for use by **tomato**:
 
-- ``idle_measurement_interval``: Specifies the interval (in seconds) after which the :func:`do_measure` function of all *components* registered on the *driver* should be called. The :func:`do_measure` is only called for *components* that are idle, i.e. without a running :class:`Task`. Overrides any :obj:`DriverInterface.idle_measurement_interval`.
+- ``idle_measurement_interval``: Specifies the interval (in seconds) after which the :func:`cmp_measure` function of all *components* registered on the *driver* should be called. The :func:`cmp_measure` checks that *components* are idle, i.e. without a running :class:`Task`. Overrides any :obj:`DriverInterface.idle_measurement_interval`.
 
 
 Communication between *jobs* and *drivers*

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -59,21 +59,23 @@ def tomato_driver_bootstrap(
 def perform_idle_measurements(
     interface: ModelInterface, t_last: Union[float, None]
 ) -> Union[float, None]:
+    if not hasattr(interface, "cmp_measure"):
+        return t_last
+
     if "idle_measurement_interval" in interface.settings:
         imi = interface.settings["idle_measurement_interval"]
     elif hasattr(interface, "idle_measurement_interval"):
         imi = interface.idle_measurement_interval
     else:
         imi = IDLE_MEASUREMENT_INTERVAL
-    t_now = time.perf_counter()
     if imi is None:
         return None
+    
+    t_now = time.perf_counter()
     if t_last is not None and t_now - t_last < imi:
         return t_last
-    for cname, cmp in interface.devmap.items():
-        if cmp.running is False and hasattr(cmp, "do_measure"):
-            logger.debug("running measurement on component %s", cname)
-            cmp.do_measure()
+    for key in interface.devmap.keys():
+        interface.cmp_measure(key=key)
     return t_now
 
 

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -70,7 +70,7 @@ def perform_idle_measurements(
         imi = IDLE_MEASUREMENT_INTERVAL
     if imi is None:
         return None
-    
+
     t_now = time.perf_counter()
     if t_last is not None and t_now - t_last < imi:
         return t_last

--- a/src/tomato/driverinterface_2_0/__init__.py
+++ b/src/tomato/driverinterface_2_0/__init__.py
@@ -131,9 +131,10 @@ class ModelInterface(metaclass=ABCMeta):
 
     # Class attributes
     version: str = "2.0"
+    """Version of the :obj:`DriverInterface`."""
 
     idle_measurement_interval: Union[int, None] = None
-    """The interval (in seconds) after which :func:`self.do_measure` will be executed, when idle."""
+    """The interval (in seconds) after which :func:`self.cmp_measure` will be executed, when idle."""
 
     # Instance attributes
     devmap: dict[tuple, "ModelDevice"]


### PR DESCRIPTION
Use `DriverInterface.cmp_measure()` instead of `Driver.do_measure()` every `DriverInterface.idle_measurement_interval`. 

- Direct access to `ModelDriver` class members is not good practice.
- The `cmp_measure()` function checks that the component is idle; no need to check for that in the `tomato-driver` process.
- The `cmp_measure()` function launches the `do_measure()` function in a separate thread, which means the `tomato-driver` process is not blocked while the measurement is done.