### PR TITLE
Implement `force` in `passata`

### DIFF
--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -12,9 +12,10 @@ Changes from ``tomato-2.0`` include:
 
 - *Driver* processess are now better at logging errors. All ``Exceptions`` raised by the :obj:`DriverInterface` should should now be caught and logged; as functionality of the *components* should only be accessed via the :obj:`DriverInterface`, this should catch all cases.
 - The :func:`cmp_measure` of each *component* can now be periodically called by the *driver* process, if a task is not running. The interval (in seconds) can be configured by the user in the *driver* section of the |setfile|_ (under ``driver.<driver_name>.idle_measurement_interval``) or provided by the driver developer (under :obj:`DriverInterface.idle_measurement_interval`); it falls back to ``None`` which means no periodic measurement will be done.
+- Functions in the :mod:`tomato.passata` module that change the *component* state now check whether the *component* has a running task. If a *component* is running, a change of state (via :func:`~tomato.passata.reset` or :func:`~tomato.passata.set_attr`) can be forced by setting ``force=True``.
 - A new ``DriverInterface-2.1``, with the following changes:
   - :class:`~tomato.driverinterface_2_1.Attr` now accepts ``options``, which is the :class:`set` of values this attribute can be set to.
-  - The decorators are now in :mod:`tomato.driverinterface_2_1.decorators`
+  - The decorators are now in :mod:`tomato.driverinterface_2_1.decorators`.
   - A new decorator, :func:`~tomato.driverinterface_2_1.decorators.coerce_val`, is provided to allow simpler type conversion and boundary checking.
 
 .. codeauthor::

--- a/src/tomato/driverinterface_2_1/__init__.py
+++ b/src/tomato/driverinterface_2_1/__init__.py
@@ -69,13 +69,19 @@ class ModelInterface(metaclass=ABCMeta):
 
     """
 
+    # Class attributes
     version: str = "2.1"
+    """Version of the :obj:`DriverInterface`."""
 
+    idle_measurement_interval: Union[int, None] = None
+    """The interval (in seconds) after which :func:`self.cmp_measure` will be executed, when idle."""
+
+    # Instance attributes
     devmap: dict[tuple, "ModelDevice"]
     """Map of registered devices, the tuple keys are `component = (address, channel)`"""
 
     settings: dict[str, Any]
-    """A settings map to contain driver-specific settings such as `dllpath` for BioLogic"""
+    """A settings map to contain driver-specific settings such as ``dllpath`` for BioLogic"""
 
     constants: dict[str, Any]
     """A map that should be populated with driver-specific run-time constants."""

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -27,11 +27,11 @@ def _name_to_cmp(
 
 
 def _running_or_force(
-        name: str,
-        port: int,
-        timeout: int,
-        context: zmq.Context,
-        force: bool,
+    name: str,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    force: bool,
 ) -> Reply:
     if not force:
         ret = status(port=port, timeout=timeout, context=context, name=name).data
@@ -39,7 +39,7 @@ def _running_or_force(
             return Reply(
                 success=False,
                 msg=f"will not 'set_attr' on a running component {name!r}",
-                data=None
+                data=None,
             )
     return Reply(success=True)
 

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -129,6 +129,33 @@ def test_passata_api_measure(start_tomato_daemon, stop_tomato_daemon):
     assert ret.success
 
 
+def test_passata_api_force(datadir, start_tomato_daemon, stop_tomato_daemon):
+    utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
+    utils.run_casenames(["counter_5_0.2"], [None], ["pip-counter"])
+    assert utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
+
+    ret = tomato.passata.set_attr(
+        name="example_counter:(example-addr,1)",
+        attr="max",
+        val=15,
+        force=False,
+        **kwargs,
+    )
+    assert ret.success is False
+    assert "running component" in ret.msg
+
+    ret = tomato.passata.set_attr(
+        name="example_counter:(example-addr,1)",
+        attr="max",
+        val=15,
+        force=True,
+        **kwargs,
+    )
+    assert ret.success
+    assert "set to 15.0" in ret.msg
+
+
 def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):
     utils.wait_until_tomato_running(port=PORT, timeout=1000)
     utils.wait_until_tomato_drivers(port=PORT, timeout=3000)


### PR DESCRIPTION
Implements a `force: bool=False` argument to the `reset()` and `set_attr()` functions in passata, so that running jobs cannot be unintentionally messed with.

Closes #133.