### PR TITLE
Fix some `driver` crashes

### DIFF
--- a/docs/source/driver_develop.rst
+++ b/docs/source/driver_develop.rst
@@ -54,6 +54,12 @@ Best Practices when developing a *driver*
 - The :func:`ModelDevice.attrs` defines the variable attributes of the *component* that should be accessible, using :class:`Attr`. All entries in :func:`attrs` should also be present in :obj:`ModelDevice.data`, as the data likely depends on the settings of these :class:`Attrs`.
 - Each :class:`ModelDevice` contains a link to its parent :class:`ModelInterface` in the :obj:`ModelDevice.driver` object.
 - Internal functions of the :class:`ModelDevice` and :class:`ModelInterface` should be re-used wherever possible. E.g., reading *component* attributes should always be carried out using :func:`ModelDevice.get_attr`.
+- Only certain types of Exceptions are caught and logged by the ``tomato-driver`` process:
+
+  - The :func:`__init__` of each :class:`ModelDevice` should raise :class:`RuntimeError` if connection to the *component*/*device* was not possible. The instantiation of the *component* (via :func:`ModelInterface.cmp_register`) will be carried out automatically 3x, then it has to be done manually via ``passata register``.
+  - The :func:`set_attr` and :func:`get_attr` (and others) should raise :class:`ValueError` or :class:`AttributeError` if the val/attr supplied by the user is invalid. The expectation is that when one of these Exceptions is raised, there is no change to the state of the *component*.
+
+  Other types of Exceptions are not caught and **will** cause the ``tomato-driver`` process to crash.
 
 DriverInterface ver. 2.1
 ````````````````````````

--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -13,11 +13,16 @@ Changes from ``tomato-2.0`` include:
 - *Driver* processess are now better at logging errors. All ``Exceptions`` raised by the :obj:`DriverInterface` should should now be caught and logged; as functionality of the *components* should only be accessed via the :obj:`DriverInterface`, this should catch all cases.
 - The :func:`cmp_measure` of each *component* can now be periodically called by the *driver* process, if a task is not running. The interval (in seconds) can be configured by the user in the *driver* section of the |setfile|_ (under ``driver.<driver_name>.idle_measurement_interval``) or provided by the driver developer (under :obj:`DriverInterface.idle_measurement_interval`); it falls back to ``None`` which means no periodic measurement will be done.
 - Functions in the :mod:`tomato.passata` module that change the *component* state now check whether the *component* has a running task. If a *component* is running, a change of state (via :func:`~tomato.passata.reset` or :func:`~tomato.passata.set_attr`) can be forced by setting ``force=True``.
+- A new :func:`tomato.passata.register` function (and CLI invocation ``passata register <component>``), in order to retry component registration.
 - A new ``DriverInterface-2.1``, with the following changes:
 
   - :class:`~tomato.driverinterface_2_1.Attr` now accepts ``options``, which is the :class:`set` of values this attribute can be set to.
   - The decorators are now in :mod:`tomato.driverinterface_2_1.decorators`.
   - A new decorator, :func:`~tomato.driverinterface_2_1.decorators.coerce_val`, is provided to allow simpler type conversion and boundary checking.
+  - Better error handling in ``tomato-driver`` processes; the following guidelines should be followed:
+
+    - :class:`ValueError` or :class:`AttributeError` should be raised by the component methods when wrong vals or attrs are supplied/queried (:func:`get_attr`, :func:`set_attr`); those exception types will be caught, logged, and the ``tomato-driver`` won't crash
+    - :class:`RuntimeError` should be raised by the component :func:`__init__` during component registration; this exception type will be caught, logged, and re-registration will be attempted at most 3 x in total by the ``tomato-daemon``
 
 - A new ``Payload-2.1``, with the following changes to ``Task`` specification in ``Payload.method``:
 

--- a/src/tomato/__init__.py
+++ b/src/tomato/__init__.py
@@ -313,11 +313,12 @@ def run_passata():
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
     stats = subparsers.add_parser("status")
     attrs = subparsers.add_parser("attrs")
+    regis = subparsers.add_parser("register")
     capbs = subparsers.add_parser("capabilities")
     const = subparsers.add_parser("constants")
     gattr = subparsers.add_parser("get")
 
-    for p in [stats, attrs, capbs, gattr, const]:
+    for p in [stats, attrs, regis, capbs, gattr, const]:
         p.add_argument(
             "name",
             help=(
@@ -355,6 +356,7 @@ def run_passata():
 
     stats.set_defaults(func=passata.status)
     attrs.set_defaults(func=passata.attrs)
+    regis.set_defaults(func=passata.register)
     capbs.set_defaults(func=passata.capabilities)
     const.set_defaults(func=passata.constants)
     gattr.set_defaults(func=passata.get_attrs)

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -220,9 +220,22 @@ def tomato_driver() -> None:
                     data=msg.get("params"),
                 )
             elif hasattr(interface, msg["cmd"]):
-                ret = getattr(interface, msg["cmd"])(**msg["params"])
+                try:
+                    ret = getattr(interface, msg["cmd"])(**msg["params"])
+                except (ValueError, AttributeError) as e:
+                    logger.info("above error caught by driver process")
+                    ret = Reply(
+                        success=False,
+                        msg=f"{type(e)}: {str(e)}",
+                        data=None,
+                    )
             else:
                 logger.critical("unknown command: '%s'", msg["cmd"])
+                ret = Reply(
+                    success=False,
+                    msg=f"unknown command: {msg['cmd']}",
+                    data=None,
+                )
             logger.debug("replying %s", ret)
             rep.send_pyobj(ret)
         if status == "stop":

--- a/src/tomato/driverinterface_1_0/__init__.py
+++ b/src/tomato/driverinterface_1_0/__init__.py
@@ -230,11 +230,14 @@ class ModelInterface(metaclass=ABCMeta):
     devmap: dict[tuple, DeviceManager]
     """Map of registered devices, the tuple keys are `component = (address, channel)`"""
 
+    retries: dict
+
     settings: dict[str, Any]
     """A settings map to contain driver-specific settings such as `dllpath` for BioLogic"""
 
     def __init__(self, settings=None):
         self.devmap = {}
+        self.retries = defaultdict(int)
         self.settings = settings if settings is not None else {}
 
     def dev_register(self, address: str, channel: str, **kwargs: dict) -> Reply:

--- a/src/tomato/driverinterface_2_1/__init__.py
+++ b/src/tomato/driverinterface_2_1/__init__.py
@@ -78,7 +78,10 @@ class ModelInterface(metaclass=ABCMeta):
 
     # Instance attributes
     devmap: dict[tuple, "ModelDevice"]
-    """Map of registered devices, the tuple keys are `component = (address, channel)`"""
+    """Map of registered device components, the tuple keys are `component = (address, channel)`"""
+
+    retries: dict[tuple, int]
+    """Map of components which failed to register, with number of retries as values."""
 
     settings: dict[str, Any]
     """A settings map to contain driver-specific settings such as ``dllpath`` for BioLogic"""
@@ -170,9 +173,17 @@ class ModelInterface(metaclass=ABCMeta):
         :obj:`Reply.data`.
         """
         key = (address, channel)
-        self.devmap[key] = self.DeviceFactory(key, **kwargs)
-        capabs = self.devmap[key].capabilities()
-        return (True, f"device {key!r} registered", capabs)
+        try:
+            self.devmap[key] = self.DeviceFactory(key, **kwargs)
+            capabs = self.devmap[key].capabilities()
+            return (True, f"device {key!r} registered", capabs)
+        except RuntimeError as e:
+            if key not in self.retries:
+                self.retries[key] = 1
+            else:
+                self.retries[key] += 1
+            return (False, f"failed to register {key!r}: {str(e)}", None)
+
 
     @log_errors
     @to_reply
@@ -432,34 +443,39 @@ class ModelInterface(metaclass=ABCMeta):
             msg = f"unknown task {task.technique_name!r} requested"
             return (False, msg, None)
         attrs = self.devmap[key].attrs(**kwargs)
-        for par, val in task.task_params.items():
-            if par not in attrs:
-                msg = f"unknown attribute {par!r} cannot be set"
+        for attr, val in task.task_params.items():
+            if val is None:
+                msg = f"val of attr {attr!r} cannot be None"
                 return (False, msg, None)
-            props = attrs[par]
+            if attr not in attrs:
+                msg = f"unknown attr: {attr!r}"
+                return (False, msg, None)
+            props = attrs[attr]
             if not props.rw:
-                msg = f"attribute {par!r} is read-only"
+                msg = f"attribute {attr!r} is read-only"
                 return (False, msg, None)
+
             if not isinstance(val, props.type):
                 try:
                     val = props.type(val)
                 except (ValueError, pint.errors.UndefinedUnitError):
-                    msg = f"could not coerce {par!r} to type {props.type}"
+                    msg = f"could not coerce {attr!r} to type {props.type}"
                     return (False, msg, None)
             if props.options is not None and val not in props.options:
-                msg = f"{par!r} value {val!r} not among allowed options={props.options}"
+                msg = f"val {val!r} is not among allowed options {props.options}"
                 return (False, msg, None)
+
             if isinstance(val, pint.Quantity):
                 if val.dimensionless and props.units is not None:
                     val = pint.Quantity(val.m, props.units)
                 if val.dimensionality != pint.Quantity(props.units).dimensionality:
-                    msg = f"attribute {par!r} has the wrong dimensionality {str(val.dimensionality)}"
+                    msg = f"val {val!r} has the wrong dimensionality"
                     return (False, msg, None)
             if props.minimum is not None and val < props.minimum:
-                msg = f"attr {par!r} is smaller than {props.minimum}"
+                msg = f"val {val!r} is smaller than {props.minimum}"
                 return (False, msg, None)
             if props.maximum is not None and val > props.maximum:
-                msg = f"attr {par!r} is greater than {props.maximum}"
+                msg = f"val {val!r} is greater than {props.maximum}"
                 return (False, msg, None)
         return (True, "task validated successfully", None)
 

--- a/src/tomato/driverinterface_2_1/__init__.py
+++ b/src/tomato/driverinterface_2_1/__init__.py
@@ -259,6 +259,7 @@ class ModelInterface(metaclass=ABCMeta):
         Iterates over all :class:`Attrs` on the component that have ``status=True`` and
         returns their values in the :obj:`Reply.data` as a :class:`dict`.
         """
+        logger.critical(f"we made it here: {self.devmap=}")
         ret = {}
         for k, attr in self.devmap[key].attrs(key=key, **kwargs).items():
             if attr.status:

--- a/src/tomato/driverinterface_2_1/decorators.py
+++ b/src/tomato/driverinterface_2_1/decorators.py
@@ -19,8 +19,8 @@ def in_devmap(func):
             channel = kwargs.get("channel")
             key = (address, channel)
         if key not in self.devmap:
-            msg = f"dev with address {address!r} and channel {channel} is unknown"
-            return Reply(success=False, msg=msg, data=self.devmap.keys())
+            msg = f"component with key {key!r} is unknown"
+            return Reply(success=False, msg=msg, data=None)
         return func(self, **kwargs, key=key)
 
     return wrapper

--- a/src/tomato/driverinterface_2_1/decorators.py
+++ b/src/tomato/driverinterface_2_1/decorators.py
@@ -19,7 +19,7 @@ def in_devmap(func):
             channel = kwargs.get("channel")
             key = (address, channel)
         if key not in self.devmap:
-            msg = f"component with key {key!r} is unknown"
+            msg = f"component with key {key!r} is not registered"
             return Reply(success=False, msg=msg, data=None)
         return func(self, **kwargs, key=key)
 

--- a/src/tomato/driverinterface_2_1/decorators.py
+++ b/src/tomato/driverinterface_2_1/decorators.py
@@ -56,9 +56,9 @@ def log_errors(func):
     def wrapper(self, **kwargs):
         try:
             return func(self, **kwargs)
-        # We want to preserve ValueErrors and AssertionErrors for testing.
+        # We want to preserve TypeErrors, ValueErrors and AttributeErrors for testing.
         # These should be then caught in the tomato-driver process.
-        except (ValueError, AssertionError) as e:
+        except (ValueError, AttributeError) as e:
             logger.critical(e, exc_info=True)
             raise e
         # Other kinds of errors we abort the driver process
@@ -81,28 +81,29 @@ def coerce_val(func):
 
     @wraps(func)
     def wrapper(self, attr: str, val: Val, **kwargs: dict) -> Val:
-        assert val is not None, f"val of attr {attr!r} cannot be None"
-        assert attr in self.attrs(), f"unknown attr: {attr!r}"
+        if val is None:
+            raise ValueError(f"attr {attr!r} cannot be None")
+        if attr not in self.attrs():
+            raise AttributeError(f"unknown attr: {attr!r}")
         props = self.attrs()[attr]
-        assert props.rw
+        if not props.rw:
+            raise AttributeError(f"attr {attr!r} is read-only")
 
         if not isinstance(val, props.type):
+            # This may raise ValueError
             val = props.type(val)
-        assert props.options is None or val in props.options, (
-            f"val {val!r} is not in allowed options {props.options}"
-        )
+        if props.options is not None and val not in props.options:
+            raise ValueError(f"val {val!r} is not in allowed options {props.options}")
+
         if isinstance(val, pint.Quantity):
             if val.dimensionless and props.units is not None:
                 val = pint.Quantity(val.m, props.units)
-            assert val.dimensionality == pint.Quantity(props.units).dimensionality, (
-                f"attr {attr!r} has the wrong dimensionality {str(val.dimensionality)}"
-            )
-        assert props.minimum is None or val >= props.minimum, (
-            f"attr {attr!r} is smaller than {props.minimum}"
-        )
-        assert props.maximum is None or val <= props.maximum, (
-            f"attr {attr!r} is greater than {props.maximum}"
-        )
+            if val.dimensionality != pint.Quantity(props.units).dimensionality:
+                raise ValueError(f"val {val!r} has the wrong dimensionality")
+        if props.minimum is not None and val < props.minimum:
+            raise ValueError(f"val {val!r} is smaller than {props.minimum}")
+        if props.maximum is not None and val > props.maximum:
+            raise ValueError(f"val {val!r} is greater than {props.maximum}")
 
         return func(self, attr=attr, val=val, **kwargs)
 

--- a/src/tomato/passata/__init__.py
+++ b/src/tomato/passata/__init__.py
@@ -69,6 +69,31 @@ def status(
     return ret
 
 
+def register(
+    *,
+    port: int,
+    timeout: int,
+    context: zmq.Context,
+    name: str,
+    **_: dict,
+) -> Reply:
+    ret = _name_to_cmp(name, port, timeout, context)
+    if isinstance(ret, Reply):
+        return ret
+    cmp, drv = ret
+
+    kwargs = dict(channel=cmp.channel, address=cmp.address)
+    req = context.socket(zmq.REQ)
+    req.connect(f"tcp://127.0.0.1:{drv.port}")
+    if drv.version == "1.0":
+        req.send_pyobj(dict(cmd="dev_register", params={**kwargs}))
+    else:
+        req.send_pyobj(dict(cmd="cmp_register", params={**kwargs}))
+    ret = req.recv_pyobj()
+    req.close()
+    return ret
+
+
 def attrs(
     *,
     port: int,

--- a/src/tomato/tomato/__init__.py
+++ b/src/tomato/tomato/__init__.py
@@ -209,7 +209,7 @@ def _status_helper(daemon: Daemon, yaml: bool, stgrp: str):
         else:
             ii = []
             for i in daemon.cmps.values():
-                line = f"name:{i.name}\tdriver:{i.driver}\tdevice:{i.device}\trole:{i.role}"
+                line = f"name:{i.name}\tdriver:{i.driver}\tdevice:{i.device}\trole:{i.role}\tcapabs:{i.capabilities}"
                 ii.append(line)
             if len(ii) == 0:
                 msg = f"tomato running on port {daemon.port} with no components"


### PR DESCRIPTION
This PR:
- limits retrying of component registration to 3x
- implements `passata register <name>` to try to re-register known but not registered components
- reworks exception handling in `DriverInterface-2.1`:
  - the component constructor should raise `RuntimeError` in case the component initialization fails; this will be caught by the `tomato-driver` process and won't crash the whole driver
  - the component functions should raise `ValueError` or `AttributeError` when wrong values or attributes are passed; this will be caught by the `tomato-driver` process and won't crash the whole driver