### PR TITLE
Further fixes

### DIFF
--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -495,7 +495,7 @@ def manager(port: int, timeout: int = 1000):
             )
             ret = stop_tomato_driver(driver.port, context)
             if ret.success:
-                params = dict(driver=driver.name, port=None)
+                params = dict(name=driver.name, port=None)
                 req.send_pyobj(dict(cmd="driver", params=params))
                 ret = req.recv_pyobj()
 

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -92,6 +92,7 @@ def perform_idle_measurements(
         interface.cmp_measure(key=key)
     return t_now
 
+
 def kill_tomato_driver(pid: int):
     """
     Wrapper around :func:`psutil.terminate`.
@@ -114,6 +115,7 @@ def kill_tomato_driver(pid: int):
     logger.debug(f"{gone=}")
     logger.debug(f"{alive=}")
     return gone
+
 
 def tomato_driver() -> None:
     """

--- a/src/tomato/daemon/driver.py
+++ b/src/tomato/daemon/driver.py
@@ -160,7 +160,13 @@ def tomato_driver() -> None:
 
     logger.debug("getting pid")
     if psutil.WINDOWS:
-        pid = os.getppid()
+        pid = os.getpid()
+        thispid = os.getpid()
+        thisproc = psutil.Process(thispid)
+        for p in thisproc.parents():
+            if p.name() == "tomato-driver.exe":
+                pid = p.pid
+                break
     elif psutil.POSIX:
         pid = os.getpid()
 

--- a/src/tomato/daemon/job.py
+++ b/src/tomato/daemon/job.py
@@ -553,13 +553,15 @@ def job_thread(
             ):
                 logger.info("task %s:%d stop trigger met", component.role, ti)
                 try:
+                    req.RCVTIMEO = 10000
                     req.send_pyobj(dict(cmd="task_stop", params={**kwargs}))
                     ret = req.recv_pyobj()
+                    req.RCVTIMEO = 1000
                 except zmq.ZMQError as e:
                     logger.critical(e, exc_info=True)
                     thread.crashed = True
                     sys.exit(e)
-                if ret.success:
+                if ret.success and ret.data is not None:
                     data_to_pickle(ret.data, datapath, role=component.role)
                 break
 

--- a/src/tomato/daemon/job.py
+++ b/src/tomato/daemon/job.py
@@ -404,7 +404,6 @@ def tomato_job() -> None:
             if p.name() == "tomato-job.exe":
                 pid = p.pid
                 break
-
     elif psutil.POSIX:
         pid = os.getpid()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import subprocess
 import psutil
 import shutil
 
+from . import utils
+
 
 @pytest.fixture
 def datadir(tmpdir, request):
@@ -31,6 +33,9 @@ def start_tomato_daemon(tmpdir: str, port: int = 12345):
     os.chdir(tmpdir)
     subprocess.run(["tomato", "init", "-p", f"{port}", "-A", ".", "-D", ".", "-L", "."])
     subprocess.run(["tomato", "start", "-p", f"{port}", "-A", ".", "-vv"])
+    assert utils.wait_until_tomato_running(port=port, timeout=1000)
+    assert utils.wait_until_tomato_drivers(port=port, timeout=3000)
+    assert utils.wait_until_tomato_components(port=port, timeout=5000)
     yield
     # teardown_stuff
 

--- a/tests/test_02_ketchup.py
+++ b/tests/test_02_ketchup.py
@@ -20,10 +20,8 @@ kwargs = dict(port=PORT, timeout=1000, context=CTXT)
 )
 def test_ketchup_submit_one(pl, jn, datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-
     ret = ketchup.submit(**kwargs, payload=pl, jobname=jn)
-    utils.wait_until_ketchup_status(jobid=1, status="q", port=PORT, timeout=1000)
+    assert utils.wait_until_ketchup_status(1, "qw", PORT, 1000)
 
     print(f"{ret=}")
     assert ret.success
@@ -33,11 +31,9 @@ def test_ketchup_submit_one(pl, jn, datadir, start_tomato_daemon, stop_tomato_da
 
 def test_ketchup_submit_two(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-
     ret = ketchup.submit(payload="counter_1_0.1.yml", jobname="job-1", **kwargs)
     ret = ketchup.submit(payload="counter_5_0.2.yml", jobname="job-2", **kwargs)
-    utils.wait_until_ketchup_status(jobid=2, status="q", port=PORT, timeout=1000)
+    assert utils.wait_until_ketchup_status(2, "qw", PORT, 1000)
 
     print(f"{ret=}")
     assert ret.success
@@ -46,8 +42,6 @@ def test_ketchup_submit_two(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_ketchup_status_empty(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-
     ret = ketchup.status(**kwargs, verbosity=0, jobids=[])
     print(f"{ret=}")
     assert not ret.success
@@ -56,11 +50,9 @@ def test_ketchup_status_empty(start_tomato_daemon, stop_tomato_daemon):
 
 def test_ketchup_status_all_queued(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-
     ret = ketchup.submit(payload="counter_1_0.1.yml", jobname="job-1", **kwargs)
     ret = ketchup.submit(payload="counter_5_0.2.yml", jobname="job-2", **kwargs)
-    utils.wait_until_ketchup_status(jobid=2, status="q", port=PORT, timeout=1000)
+    assert utils.wait_until_ketchup_status(2, "qw", PORT, 1000)
 
     ret = ketchup.status(**kwargs, verbosity=0, jobids=[])
     print(f"{ret=}")
@@ -71,11 +63,9 @@ def test_ketchup_status_all_queued(datadir, start_tomato_daemon, stop_tomato_dae
 
 def test_ketchup_status_one_queued(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-
     ret = ketchup.submit(payload="counter_1_0.1.yml", jobname="job-1", **kwargs)
     ret = ketchup.submit(payload="counter_5_0.2.yml", jobname="job-2", **kwargs)
-    utils.wait_until_ketchup_status(jobid=2, status="q", port=PORT, timeout=1000)
+    assert utils.wait_until_ketchup_status(2, "qw", PORT, 1000)
 
     ret = ketchup.status(**kwargs, verbosity=0, jobids=[2])
     print(f"{ret=}")
@@ -87,11 +77,9 @@ def test_ketchup_status_one_queued(datadir, start_tomato_daemon, stop_tomato_dae
 
 def test_ketchup_status_two_queued(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-
     ret = ketchup.submit(payload="counter_1_0.1.yml", jobname="job-1", **kwargs)
     ret = ketchup.submit(payload="counter_5_0.2.yml", jobname="job-2", **kwargs)
-    utils.wait_until_ketchup_status(jobid=2, status="q", port=PORT, timeout=1000)
+    assert utils.wait_until_ketchup_status(2, "qw", PORT, 1000)
 
     ret = ketchup.status(**kwargs, verbosity=0, jobids=[1, 2])
     print(f"{ret=}")
@@ -104,12 +92,8 @@ def test_ketchup_status_two_queued(datadir, start_tomato_daemon, stop_tomato_dae
 
 def test_ketchup_status_running(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames(["counter_5_0.2"], [None], ["pip-counter"])
-    assert utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
+    assert utils.wait_until_ketchup_status(1, "r", PORT, 5000)
 
     ret = ketchup.status(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
@@ -121,14 +105,10 @@ def test_ketchup_status_running(datadir, start_tomato_daemon, stop_tomato_daemon
 
 def test_ketchup_status_complete(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames(["counter_1_0.1"], [None], ["pip-counter"])
-    utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
+    assert utils.wait_until_ketchup_status(1, "r", PORT, 5000)
 
-    assert utils.wait_until_ketchup_status(jobid=1, status="c", port=PORT, timeout=5000)
+    assert utils.wait_until_ketchup_status(1, "c", PORT, 5000)
     ret = ketchup.status(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
     assert ret.success
@@ -138,12 +118,8 @@ def test_ketchup_status_complete(datadir, start_tomato_daemon, stop_tomato_daemo
 
 def test_ketchup_cancel_running(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames(["counter_60_0.1"], [None], ["pip-counter"])
-    assert utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
+    assert utils.wait_until_ketchup_status(1, "r", PORT, 5000)
 
     assert utils.wait_until_pickle(jobid=1, timeout=2000)
     ret = ketchup.cancel(**kwargs, verbosity=0, jobids=[1])
@@ -151,9 +127,7 @@ def test_ketchup_cancel_running(datadir, start_tomato_daemon, stop_tomato_daemon
     assert ret.success
     assert ret.data[0].status == "rd"
 
-    assert utils.wait_until_ketchup_status(
-        jobid=1, status="cd", port=PORT, timeout=5000
-    )
+    assert utils.wait_until_ketchup_status(1, "cd", PORT, 5000)
     ret = ketchup.status(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
     print(f"{os.listdir()=}")
@@ -165,15 +139,9 @@ def test_ketchup_cancel_running(datadir, start_tomato_daemon, stop_tomato_daemon
 
 def test_ketchup_cancel_queued(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     ret = ketchup.submit(payload="counter_60_0.1.yml", jobname=None, **kwargs)
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid="counter_60_0.1")
-    assert utils.wait_until_ketchup_status(
-        jobid=1, status="qw", port=PORT, timeout=5000
-    )
+    assert utils.wait_until_ketchup_status(1, "qw", PORT, 5000)
 
     ret = ketchup.cancel(**kwargs, verbosity=0, jobids=[1])
     print(f"{ret=}")
@@ -183,12 +151,8 @@ def test_ketchup_cancel_queued(datadir, start_tomato_daemon, stop_tomato_daemon)
 
 def test_ketchup_snapshot(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames(["counter_60_0.1"], [None], ["pip-counter"])
-    assert utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
+    assert utils.wait_until_ketchup_status(1, "r", PORT, 5000)
 
     assert utils.wait_until_pickle(jobid=1, timeout=2000)
     ret = ketchup.snapshot(jobids=[1], port=PORT, context=CTXT)
@@ -199,8 +163,6 @@ def test_ketchup_snapshot(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 def test_ketchup_search(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-
     ret = ketchup.submit(payload="counter_1_0.1.yml", jobname="job-1", **kwargs)
     ret = ketchup.submit(payload="counter_5_0.2.yml", jobname="job-2", **kwargs)
 
@@ -230,10 +192,6 @@ def test_ketchup_search(datadir, start_tomato_daemon, stop_tomato_daemon):
 )
 def test_ketchup_validation(pl, jn, datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     ret = ketchup.submit(**kwargs, payload=pl, jobname=jn)
     print(f"{ret=}")
     assert ret.success

--- a/tests/test_03_state.py
+++ b/tests/test_03_state.py
@@ -16,10 +16,10 @@ kwargs = dict(port=PORT, timeout=1000, context=CTXT)
 
 
 def test_stop_with_queued_jobs(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=WAIT)
     os.chdir(datadir)
     ketchup.submit(payload="counter_1_0.1.yml", jobname="job-1", **kwargs)
     ketchup.submit(payload="counter_5_0.2.yml", jobname="job-2", **kwargs)
+
     time.sleep(1)
     tomato.stop(**kwargs)
     assert utils.wait_until_tomato_stopped(port=PORT, timeout=5000)
@@ -34,12 +34,12 @@ def test_stop_with_queued_jobs(datadir, start_tomato_daemon, stop_tomato_daemon)
 
 
 def test_stop_with_running_jobs(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=WAIT)
     os.chdir(datadir)
     ketchup.submit(payload="counter_5_0.2.yml", jobname="job-1", **kwargs)
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid="counter_5_0.2")
     tomato.pipeline_ready(**kwargs, pipeline="pip-counter")
-    utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=WAIT)
+    assert utils.wait_until_ketchup_status(1, "r", PORT, WAIT)
+
     ret = tomato.stop(**kwargs)
     print(f"{ret=}")
     assert ret.success is False
@@ -47,12 +47,11 @@ def test_stop_with_running_jobs(datadir, start_tomato_daemon, stop_tomato_daemon
 
 
 def test_restart_with_running_jobs(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=WAIT)
     os.chdir(datadir)
     ketchup.submit(payload="counter_20_5.yml", jobname="job-1", **kwargs)
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid="counter_20_5")
     tomato.pipeline_ready(**kwargs, pipeline="pip-counter")
-    assert utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=WAIT)
+    assert utils.wait_until_ketchup_status(1, "r", PORT, WAIT)
 
     ret = tomato.stop(**kwargs)
     utils.kill_tomato_daemon(port=PORT)
@@ -67,9 +66,7 @@ def test_restart_with_running_jobs(datadir, start_tomato_daemon, stop_tomato_dae
     assert len(ret.data) == 1
     assert ret.data[0].status == "r"
 
-    assert utils.wait_until_ketchup_status(
-        jobid=1, status="c", port=PORT, timeout=25000
-    )
+    assert utils.wait_until_ketchup_status(1, "c", PORT, 25000)
     ret = ketchup.status(**kwargs, jobids=[1], verbosity=logging.DEBUG)
     print(f"{ret=}")
     assert ret.success
@@ -79,9 +76,6 @@ def test_restart_with_running_jobs(datadir, start_tomato_daemon, stop_tomato_dae
 
 def test_restart_with_complete_jobs(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ketchup.submit(payload="counter_5_0.2.yml", jobname="job-1", **kwargs)
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid="counter_5_0.2")
     tomato.pipeline_ready(**kwargs, pipeline="pip-counter")
@@ -104,9 +98,6 @@ def test_restart_with_complete_jobs(datadir, start_tomato_daemon, stop_tomato_da
 
 def test_restart_with_crashed_jobs(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ketchup.submit(payload="counter_20_5.yml", jobname="job-1", **kwargs)
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid="counter_20_5")
     tomato.pipeline_ready(**kwargs, pipeline="pip-counter")
@@ -134,13 +125,11 @@ def test_restart_with_crashed_jobs(datadir, start_tomato_daemon, stop_tomato_dae
 
 
 def test_crashed_driver_restarts(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=WAIT)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     os.chdir(datadir)
-
     ret = tomato.status(**kwargs, stgrp="drivers")
     assert ret.success
     print(f"{ret.data=}")
+
     pid = ret.data["example_counter"].pid
     p = psutil.Process(pid)
     p.terminate()
@@ -149,7 +138,7 @@ def test_crashed_driver_restarts(datadir, start_tomato_daemon, stop_tomato_daemo
     print(f"{alive=}")
     time.sleep(5)
 
-    ret = tomato.status(port=PORT, timeout=1000, context=CTXT, stgrp="drivers")
+    ret = tomato.status(PORT, 1000, CTXT, "drivers")
     assert ret.success
     print(f"{ret.data=}")
     assert pid != ret.data["example_counter"].pid
@@ -159,9 +148,6 @@ def test_crashed_driver_with_running_jobs(
     datadir, start_tomato_daemon, stop_tomato_daemon
 ):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ketchup.submit(payload="counter_5_0.2.yml", jobname="job-1", **kwargs)
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid="counter_5_0.2")
     tomato.pipeline_ready(**kwargs, pipeline="pip-counter")

--- a/tests/test_03_state.py
+++ b/tests/test_03_state.py
@@ -138,15 +138,13 @@ def test_crashed_driver_restarts(datadir, start_tomato_daemon, stop_tomato_daemo
     print(f"{alive=}")
     time.sleep(5)
 
-    ret = tomato.status(PORT, 1000, CTXT, "drivers")
+    ret = tomato.status(**kwargs, stgrp="drivers")
     assert ret.success
     print(f"{ret.data=}")
     assert pid != ret.data["example_counter"].pid
 
 
-def test_crashed_driver_with_running_jobs(
-    datadir, start_tomato_daemon, stop_tomato_daemon
-):
+def test_crashed_driver_with_jobs(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
     ketchup.submit(payload="counter_5_0.2.yml", jobname="job-1", **kwargs)
     tomato.pipeline_load(**kwargs, pipeline="pip-counter", sampleid="counter_5_0.2")

--- a/tests/test_04_tomato_reload.py
+++ b/tests/test_04_tomato_reload.py
@@ -13,7 +13,6 @@ kwargs = dict(port=PORT, context=CTXT, timeout=timeout)
 
 
 def test_reload_noop(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=timeout)
     ret = tomato.reload(**kwargs, appdir=Path())
     assert ret.success
     assert len(ret.data.drvs) == 1
@@ -23,8 +22,6 @@ def test_reload_noop(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_reload_settings(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=timeout)
-
     with open("settings.toml", "a") as inf:
         inf.write("example_counter.testparb = 1")
     ret = tomato.reload(**kwargs, appdir=Path())
@@ -38,8 +35,6 @@ def test_reload_settings(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_reload_cmps_pips(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=timeout)
-
     with open("devices_counter.json", "r") as inf:
         jsdata = json.load(inf)
     with open("devices.yml", "w") as ouf:
@@ -55,8 +50,6 @@ def test_reload_cmps_pips(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_reload_devs(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=timeout)
-
     with open("devices_multidev.json", "r") as inf:
         jsdata = json.load(inf)
     with open("devices.yml", "w") as ouf:
@@ -72,9 +65,6 @@ def test_reload_devs(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_reload_drvs(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=timeout)
-    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-
     # Let's add psutil driver / device
     with open("devices_psutil.json", "r") as inf:
         jsdata = json.load(inf)
@@ -89,7 +79,7 @@ def test_reload_drvs(datadir, start_tomato_daemon, stop_tomato_daemon):
     assert len(ret.data.pips) == 1
     assert len(ret.data.cmps) == 2
     assert utils.wait_until_tomato_running(port=PORT, timeout=timeout)
-    utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
+    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
 
     # Let's remove psutil driver / device and modify channels
     with open("devices_counter.json", "r") as inf:
@@ -108,8 +98,6 @@ def test_reload_drvs(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_reload_running(datadir, start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=timeout)
-
     utils.run_casenames(["counter_20_5"], [None], ["pip-counter"])
     assert utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
 

--- a/tests/test_04_tomato_reload.py
+++ b/tests/test_04_tomato_reload.py
@@ -99,7 +99,7 @@ def test_reload_drvs(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 def test_reload_running(datadir, start_tomato_daemon, stop_tomato_daemon):
     utils.run_casenames(["counter_20_5"], [None], ["pip-counter"])
-    assert utils.wait_until_ketchup_status(jobid=1, status="r", port=PORT, timeout=5000)
+    assert utils.wait_until_ketchup_status(1, "r", PORT, 5000)
 
     # Try modifying settings of a driver in use
     with open("settings.toml", "a") as inf:

--- a/tests/test_05_passata.py
+++ b/tests/test_05_passata.py
@@ -12,9 +12,6 @@ kwargs = dict(port=PORT, timeout=TIME, context=CTXT)
 
 
 def test_passata_api_status(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ret = tomato.passata.status(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -25,9 +22,6 @@ def test_passata_api_status(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_attrs(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ret = tomato.passata.attrs(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -38,9 +32,6 @@ def test_passata_api_attrs(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_capabs(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ret = tomato.passata.capabilities(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -51,9 +42,6 @@ def test_passata_api_capabs(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_get_attrs(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ret = tomato.passata.get_attrs(
         name="example_counter:(example-addr,1)",
         attrs=["max", "min"],
@@ -66,9 +54,6 @@ def test_passata_api_get_attrs(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_set_attr(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     val = random.random() * 100
     ret = tomato.passata.set_attr(
         name="example_counter:(example-addr,1)",
@@ -90,9 +75,6 @@ def test_passata_api_set_attr(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_reset(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ret = tomato.passata.reset(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -103,10 +85,6 @@ def test_passata_api_reset(start_tomato_daemon, stop_tomato_daemon):
 
 def test_passata_api_reset_force(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames(["counter_60_0.1"], [None], ["pip-counter"])
     assert utils.wait_until_ketchup_status(1, "r", PORT, 10000)
     ret = tomato.passata.status(
@@ -135,10 +113,6 @@ def test_passata_api_reset_force(datadir, start_tomato_daemon, stop_tomato_daemo
 
 
 def test_passata_api_constants(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     ret = tomato.passata.constants(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -149,10 +123,6 @@ def test_passata_api_constants(start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_api_measure_last_data(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     ret = tomato.passata.measure(
         name="example_counter:(example-addr,1)",
         **kwargs,
@@ -170,10 +140,6 @@ def test_passata_api_measure_last_data(start_tomato_daemon, stop_tomato_daemon):
 
 def test_passata_api_force(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames(["counter_5_0.2"], [None], ["pip-counter"])
     assert utils.wait_until_ketchup_status(1, "r", PORT, 5000)
 
@@ -199,9 +165,6 @@ def test_passata_api_force(datadir, start_tomato_daemon, stop_tomato_daemon):
 
 
 def test_passata_cli(start_tomato_daemon, stop_tomato_daemon):
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
     ret = subprocess.run(
         [
             "passata",

--- a/tests/test_99_example_counter.py
+++ b/tests/test_99_example_counter.py
@@ -28,10 +28,6 @@ def test_counter_npoints_metadata(
     casename, npoints, prefix, datadir, start_tomato_daemon, stop_tomato_daemon
 ):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames([casename], [None], ["pip-counter"])
     assert utils.wait_until_ketchup_status(1, "r", PORT, 10000)
     assert utils.wait_until_ketchup_status(1, "c", PORT, 20000)
@@ -58,10 +54,6 @@ def test_counter_npoints_metadata(
 )
 def test_counter_cancel(casename, datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames([casename], [None], ["pip-counter"])
     assert utils.wait_until_ketchup_status(1, "r", PORT, 10000)
 
@@ -80,10 +72,6 @@ def test_counter_snapshot_metadata(
     casename, external, datadir, start_tomato_daemon, stop_tomato_daemon
 ):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     utils.run_casenames([casename], [None], ["pip-counter"])
     assert utils.wait_until_ketchup_status(1, "r", PORT, 10000)
     if external:
@@ -134,10 +122,6 @@ def test_counter_multidev(casename, npoints, datadir, stop_tomato_daemon):
 
 def test_counter_measure_task_measure(datadir, start_tomato_daemon, stop_tomato_daemon):
     os.chdir(datadir)
-    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
-    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
-    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
-
     kwargs = dict(port=PORT, timeout=1000, context=CTXT)
     ret = tomato.passata.measure(
         name="example_counter:(example-addr,1)",

--- a/tests/test_99_psutil.py
+++ b/tests/test_99_psutil.py
@@ -31,7 +31,6 @@ def test_psutil_multidev(casename, npoints, datadir, stop_tomato_daemon):
         yaml.dump(jsdata, ouf)
     subprocess.run(["tomato", "init", "-p", f"{PORT}", "-A", ".", "-D", ".", "-L", "."])
     subprocess.run(["tomato", "start", "-p", f"{PORT}", "-A", ".", "-vv"])
-
     assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
     assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
     assert utils.wait_until_tomato_components(port=PORT, timeout=5000)

--- a/tests/test_99_stresstest.py
+++ b/tests/test_99_stresstest.py
@@ -19,7 +19,9 @@ def test_stresstest(case, nreps, datadir, stop_tomato_daemon):
     os.chdir(datadir)
     subprocess.run(["tomato", "init", "-p", f"{PORT}", "-A", ".", "-D", ".", "-L", "."])
     subprocess.run(["tomato", "start", "-p", f"{PORT}", "-A", "."])
-    utils.wait_until_tomato_running(port=PORT, timeout=3000)
+    assert utils.wait_until_tomato_running(port=PORT, timeout=1000)
+    assert utils.wait_until_tomato_drivers(port=PORT, timeout=3000)
+    assert utils.wait_until_tomato_components(port=PORT, timeout=5000)
 
     subprocess.run(["tomato", "pipeline", "load", "-p", f"{PORT}", "pip-counter", case])
     for i in range(nreps):


### PR DESCRIPTION
- let's increase the ZMQ timeout for `task_stop` to 10 s
- do not crash when `task_stop` returns `data==None`
- store `tomato-driver.exe` and `tomato-job.exe` as `pid`
- add `kill_tomato_driver()`, reset `driver.port` once `stop` command is issued